### PR TITLE
fix parsing multi directurl

### DIFF
--- a/motan-core/src/main/java/com/weibo/api/motan/cluster/support/ClusterSupport.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/cluster/support/ClusterSupport.java
@@ -305,7 +305,7 @@ public class ClusterSupport<T> implements NotifyListener {
         String[] durlArr = MotanConstants.COMMA_SPLIT_PATTERN.split(directUrlStr);
         List<URL> directUrls = new ArrayList<URL>();
         for (String dus : durlArr) {
-            URL du = URL.valueOf(dus);
+            URL du = URL.valueOf(StringTools.urlDecode(dus));
             if (du != null) {
                 directUrls.add(du);
             }

--- a/motan-core/src/main/java/com/weibo/api/motan/config/RefererConfig.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/config/RefererConfig.java
@@ -157,7 +157,7 @@ public class RefererConfig<T> extends AbstractRefererConfig {
                         durl.setHost(hostPort[0].trim());
                         durl.setPort(Integer.parseInt(hostPort[1].trim()));
                         durl.addParameter(URLParamType.nodeType.getName(), MotanConstants.NODE_TYPE_SERVICE);
-                        duBuf.append(StringTools.urlDecode(durl.toFullStr())).append(MotanConstants.COMMA_SEPARATOR);
+                        duBuf.append(StringTools.urlEncode(durl.toFullStr())).append(MotanConstants.COMMA_SEPARATOR);
                     }
                 }
                 if (duBuf.length() > 0) {

--- a/motan-core/src/main/java/com/weibo/api/motan/protocol/support/ProtocolFilterDecorator.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/protocol/support/ProtocolFilterDecorator.java
@@ -83,7 +83,8 @@ public class ProtocolFilterDecorator implements Protocol {
             lastRef = new Referer<T>() {
                 @Override
                 public Response call(Request request) {
-                    if (!f.getClass().getAnnotation(Activation.class).retry() && request.getRetries() != 0) {
+                    Activation activation = f.getClass().getAnnotation(Activation.class);
+                    if (activation != null && !activation.retry() && request.getRetries() != 0) {
                         return lf.call(request);
                     }
                     return f.filter(lf, request);


### PR DESCRIPTION
1、解析directurl时，对refer参数进行urlencode，避免解析url错误。
2、扩展filter时可以不添加Activation注解。
