### PR TITLE
add support for netty4

### DIFF
--- a/motan-transport-netty4/pom.xml
+++ b/motan-transport-netty4/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>motan</artifactId>
+        <groupId>com.weibo</groupId>
+        <version>0.1.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>motan-transport-netty4</artifactId>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>4.0.36.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>com.weibo</groupId>
+            <artifactId>motan-core</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/Netty4Decoder.java
+++ b/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/Netty4Decoder.java
@@ -1,0 +1,120 @@
+package com.weibo.api.motan.transport.netty4;
+
+import com.weibo.api.motan.codec.Codec;
+import com.weibo.api.motan.common.MotanConstants;
+import com.weibo.api.motan.exception.MotanFrameworkException;
+import com.weibo.api.motan.exception.MotanServiceException;
+import com.weibo.api.motan.rpc.DefaultResponse;
+import com.weibo.api.motan.rpc.Response;
+import com.weibo.api.motan.transport.Channel;
+import com.weibo.api.motan.util.LoggerUtil;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.List;
+
+/**
+ * Created by guohang.bao on 16/5/17.
+ */
+public class Netty4Decoder extends ByteToMessageDecoder {
+
+    private Codec codec;
+    private com.weibo.api.motan.transport.Channel client;
+    private int maxContentLength = 0;
+
+    public Netty4Decoder(Codec codec, Channel client, int maxContentLength) {
+        this.codec = codec;
+        this.client = client;
+        this.maxContentLength = maxContentLength;
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, ByteBuf byteBuf, List<Object> out) throws Exception {
+        io.netty.channel.Channel channel = ctx.channel();
+
+        if (byteBuf.readableBytes() <= MotanConstants.NETTY_HEADER) {
+            return;
+        }
+
+        byteBuf.markReaderIndex();
+
+        short type = byteBuf.readShort();
+
+        if (type != MotanConstants.NETTY_MAGIC_TYPE) {
+            byteBuf.resetReaderIndex();
+            throw new MotanFrameworkException("NettyDecoder transport header not support, type: " + type);
+        }
+
+        byte messageType = (byte) byteBuf.readShort();
+        long requestId = byteBuf.readLong();
+
+        int dataLength = byteBuf.readInt();
+
+        // FIXME 如果dataLength过大，可能导致问题
+        if (byteBuf.readableBytes() < dataLength) {
+            byteBuf.resetReaderIndex();
+            return;
+        }
+
+        if (maxContentLength > 0 && dataLength > maxContentLength) {
+            LoggerUtil.warn(
+                    "NettyDecoder transport data content length over of limit, size: {}  > {}. remote={} local={}",
+                    dataLength, maxContentLength, channel.remoteAddress(), channel.localAddress());
+            Exception e = new MotanServiceException("NettyDecoder transport data content length over of limit, size: "
+                    + dataLength + " > " + maxContentLength);
+
+            if (messageType == MotanConstants.FLAG_REQUEST) {
+                Response response = buildExceptionResponse(requestId, e);
+                channel.write(response);
+                throw e;
+            } else {
+                throw e;
+            }
+        }
+
+        // TODO use byte array pool
+        byte[] data = new byte[dataLength];
+
+        byteBuf.readBytes(data);
+
+        try {
+            String remoteIp = getRemoteIp(channel);
+            out.add(codec.decode(client, remoteIp, data));
+        } catch (Exception e) {
+            if (messageType == MotanConstants.FLAG_REQUEST) {
+                Response response = buildExceptionResponse(requestId, e);
+                channel.write(response);
+                out.add(response);
+            } else {
+                out.add(buildExceptionResponse(requestId, e));
+            }
+        }
+
+    }
+
+
+    private Response buildExceptionResponse(long requestId, Exception e) {
+        DefaultResponse response = new DefaultResponse();
+        response.setRequestId(requestId);
+        response.setException(e);
+        return response;
+    }
+
+
+    private String getRemoteIp(io.netty.channel.Channel channel) {
+        String ip = "";
+        SocketAddress remote = channel.remoteAddress();
+        if (remote != null) {
+            try {
+                ip = ((InetSocketAddress) remote).getAddress().getHostAddress();
+            } catch (Exception e) {
+                LoggerUtil.warn("get remoteIp error!dedault will use. msg:" + e.getMessage() + ", remote:" + remote.toString());
+            }
+        }
+        return ip;
+    }
+
+}

--- a/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/Netty4Encoder.java
+++ b/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/Netty4Encoder.java
@@ -1,0 +1,82 @@
+package com.weibo.api.motan.transport.netty4;
+
+import com.weibo.api.motan.codec.Codec;
+import com.weibo.api.motan.common.MotanConstants;
+import com.weibo.api.motan.rpc.DefaultResponse;
+import com.weibo.api.motan.rpc.Request;
+import com.weibo.api.motan.rpc.Response;
+import com.weibo.api.motan.util.ByteUtil;
+import com.weibo.api.motan.util.LoggerUtil;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToByteEncoder;
+
+/**
+ * Created by guohang.bao on 16/5/17.
+ */
+public class Netty4Encoder extends MessageToByteEncoder<Object> {
+
+    private Codec codec;
+    private com.weibo.api.motan.transport.Channel client;
+
+    public Netty4Encoder(Codec codec, com.weibo.api.motan.transport.Channel client) {
+        this.codec = codec;
+        this.client = client;
+    }
+
+    @Override
+    protected void encode(ChannelHandlerContext channelHandlerContext, Object message, ByteBuf out) throws Exception {
+
+        long requestId = getRequestId(message);
+        byte[] data = null;
+
+        if (message instanceof Response) {
+            try {
+                data = codec.encode(client, message);
+            } catch (Exception e) {
+                LoggerUtil.error("NettyEncoder encode error, identity=" + client.getUrl().getIdentity(), e);
+                Response response = buildExceptionResponse(requestId, e);
+                data = codec.encode(client, response);
+            }
+        } else {
+            data = codec.encode(client, message);
+        }
+
+        byte[] transportHeader = new byte[MotanConstants.NETTY_HEADER];
+        ByteUtil.short2bytes(MotanConstants.NETTY_MAGIC_TYPE, transportHeader, 0);
+        transportHeader[3] = getType(message);
+        ByteUtil.long2bytes(getRequestId(message), transportHeader, 4);
+        ByteUtil.int2bytes(data.length, transportHeader, 12);
+
+        out.writeBytes(transportHeader);
+        out.writeBytes(data);
+    }
+
+
+    private long getRequestId(Object message) {
+        if (message instanceof Request) {
+            return ((Request) message).getRequestId();
+        } else if (message instanceof Response) {
+            return ((Response) message).getRequestId();
+        } else {
+            return 0;
+        }
+    }
+
+    private byte getType(Object message) {
+        if (message instanceof Request) {
+            return MotanConstants.FLAG_REQUEST;
+        } else if (message instanceof Response) {
+            return MotanConstants.FLAG_RESPONSE;
+        } else {
+            return MotanConstants.FLAG_OTHER;
+        }
+    }
+
+    private Response buildExceptionResponse(long requestId, Exception e) {
+        DefaultResponse response = new DefaultResponse();
+        response.setRequestId(requestId);
+        response.setException(e);
+        return response;
+    }
+}

--- a/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/Netty4EndpointFactory.java
+++ b/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/Netty4EndpointFactory.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.weibo.api.motan.transport.netty4;
+
+import com.weibo.api.motan.core.extension.SpiMeta;
+import com.weibo.api.motan.rpc.URL;
+import com.weibo.api.motan.transport.Client;
+import com.weibo.api.motan.transport.MessageHandler;
+import com.weibo.api.motan.transport.Server;
+import com.weibo.api.motan.transport.netty4.client.Netty4Client;
+import com.weibo.api.motan.transport.netty4.server.Netty4Server;
+import com.weibo.api.motan.transport.support.AbstractEndpointFactory;
+
+@SpiMeta(name = "motan")
+public class Netty4EndpointFactory extends AbstractEndpointFactory {
+
+	@Override
+	protected Server innerCreateServer(URL url, MessageHandler messageHandler) {
+		return new Netty4Server(url, messageHandler);
+	}
+
+	@Override
+	protected Client innerCreateClient(URL url) {
+		return new Netty4Client(url);
+	}
+
+}

--- a/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/StandardThreadExecutor.java
+++ b/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/StandardThreadExecutor.java
@@ -1,0 +1,179 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.weibo.api.motan.transport.netty4;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * <pre>
+ * 
+ * 代码和思路主要来自于：
+ * 
+ * tomcat : 
+ * 		org.apache.catalina.core.StandardThreadExecutor
+ * 
+ * java.util.concurrent
+ * threadPoolExecutor execute执行策略： 		优先offer到queue，queue满后再扩充线程到maxThread，如果已经到了maxThread就reject 
+ * 						   		比较适合于CPU密集型应用（比如runnable内部执行的操作都在JVM内部，memory copy, or compute等等）
+ * 
+ * StandardThreadExecutor execute执行策略：	优先扩充线程到maxThread，再offer到queue，如果满了就reject 
+ * 						      	比较适合于业务处理需要远程资源的场景
+ * 
+ * </pre>
+ * 
+ * @author maijunsheng
+ * @version 创建时间：2013-6-20
+ * 
+ */
+public class StandardThreadExecutor extends ThreadPoolExecutor {
+
+	public static final int DEFAULT_MIN_THREADS = 20;
+	public static final int DEFAULT_MAX_THREADS = 200;
+	public static final int DEFAULT_MAX_IDLE_TIME = 60 * 1000; // 1 minutes
+
+	protected AtomicInteger submittedTasksCount;	// 正在处理的任务数 
+	private int maxSubmittedTaskCount;				// 最大允许同时处理的任务数
+
+	public StandardThreadExecutor() {
+		this(DEFAULT_MIN_THREADS, DEFAULT_MAX_THREADS);
+	}
+
+	public StandardThreadExecutor(int coreThread, int maxThreads) {
+		this(coreThread, maxThreads, maxThreads);
+	}
+
+	public StandardThreadExecutor(int coreThread, int maxThreads, long keepAliveTime, TimeUnit unit) {
+		this(coreThread, maxThreads, keepAliveTime, unit, maxThreads);
+	}
+
+	public StandardThreadExecutor(int coreThreads, int maxThreads, int queueCapacity) {
+		this(coreThreads, maxThreads, queueCapacity, Executors.defaultThreadFactory());
+	}
+
+	public StandardThreadExecutor(int coreThreads, int maxThreads, int queueCapacity, ThreadFactory threadFactory) {
+		this(coreThreads, maxThreads, DEFAULT_MAX_IDLE_TIME, TimeUnit.MILLISECONDS, queueCapacity, threadFactory);
+	}
+
+	public StandardThreadExecutor(int coreThreads, int maxThreads, long keepAliveTime, TimeUnit unit, int queueCapacity) {
+		this(coreThreads, maxThreads, keepAliveTime, unit, queueCapacity, Executors.defaultThreadFactory());
+	}
+
+	public StandardThreadExecutor(int coreThreads, int maxThreads, long keepAliveTime, TimeUnit unit,
+			int queueCapacity, ThreadFactory threadFactory) {
+		this(coreThreads, maxThreads, keepAliveTime, unit, queueCapacity, threadFactory, new AbortPolicy());
+	}
+
+	public StandardThreadExecutor(int coreThreads, int maxThreads, long keepAliveTime, TimeUnit unit,
+			int queueCapacity, ThreadFactory threadFactory, RejectedExecutionHandler handler) {
+		super(coreThreads, maxThreads, keepAliveTime, unit, new ExecutorQueue(), threadFactory, handler);
+		((ExecutorQueue) getQueue()).setStandardThreadExecutor(this);
+
+		submittedTasksCount = new AtomicInteger(0);
+		
+		// 最大并发任务限制： 队列buffer数 + 最大线程数 
+		maxSubmittedTaskCount = queueCapacity + maxThreads; 
+	}
+
+	public void execute(Runnable command) {
+		int count = submittedTasksCount.incrementAndGet();
+
+		// 超过最大的并发任务限制，进行 reject
+		// 依赖的LinkedTransferQueue没有长度限制，因此这里进行控制 
+		if (count > maxSubmittedTaskCount) {
+			submittedTasksCount.decrementAndGet();
+			getRejectedExecutionHandler().rejectedExecution(command, this);
+		}
+
+		try {
+			super.execute(command);
+		} catch (RejectedExecutionException rx) {
+			// there could have been contention around the queue
+			if (!((ExecutorQueue) getQueue()).force(command)) {
+				submittedTasksCount.decrementAndGet();
+
+				getRejectedExecutionHandler().rejectedExecution(command, this);
+			}
+		}
+	}
+
+	public int getSubmittedTasksCount() {
+		return this.submittedTasksCount.get();
+	}
+	
+	public int getMaxSubmittedTaskCount() {
+		return maxSubmittedTaskCount;
+	}
+
+	protected void afterExecute(Runnable r, Throwable t) {
+		submittedTasksCount.decrementAndGet();
+	}
+}
+
+/**
+ * LinkedTransferQueue 能保证更高性能，相比与LinkedBlockingQueue有明显提升 
+ * 
+ * <pre>
+ * 		1) 不过LinkedTransferQueue的缺点是没有队列长度控制，需要在外层协助控制
+ * </pre>
+ * 
+ * @author maijunsheng
+ *
+ */
+class ExecutorQueue extends LinkedTransferQueue<Runnable> {
+	private static final long serialVersionUID = -265236426751004839L;
+	StandardThreadExecutor threadPoolExecutor;
+
+	public ExecutorQueue() {
+		super();
+	}
+
+	public void setStandardThreadExecutor(StandardThreadExecutor threadPoolExecutor) {
+		this.threadPoolExecutor = threadPoolExecutor;
+	}
+
+	// 注：代码来源于 tomcat 
+	public boolean force(Runnable o) {
+		if (threadPoolExecutor.isShutdown()) {
+			throw new RejectedExecutionException("Executor not running, can't force a command into the queue");
+		}
+		// forces the item onto the queue, to be used if the task is rejected
+		return super.offer(o);
+	}
+
+	// 注：tomcat的代码进行一些小变更 
+	public boolean offer(Runnable o) {
+		int poolSize = threadPoolExecutor.getPoolSize();
+
+		// we are maxed out on threads, simply queue the object
+		if (poolSize == threadPoolExecutor.getMaximumPoolSize()) {
+			return super.offer(o);
+		}
+		// we have idle threads, just add it to the queue
+		// note that we don't use getActiveCount(), see BZ 49730
+		if (threadPoolExecutor.getSubmittedTasksCount() <= poolSize) {
+			return super.offer(o);
+		}
+		// if we have less threads than maximum force creation of a new
+		// thread
+		if (poolSize < threadPoolExecutor.getMaximumPoolSize()) {
+			return false;
+		}
+		// if we reached here, we need to add it to the queue
+		return super.offer(o);
+	}
+}

--- a/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/client/Netty4Client.java
+++ b/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/client/Netty4Client.java
@@ -1,0 +1,437 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.weibo.api.motan.transport.netty4.client;
+
+import com.weibo.api.motan.common.ChannelState;
+import com.weibo.api.motan.common.MotanConstants;
+import com.weibo.api.motan.common.URLParamType;
+import com.weibo.api.motan.exception.MotanAbstractException;
+import com.weibo.api.motan.exception.MotanErrorMsgConstant;
+import com.weibo.api.motan.exception.MotanFrameworkException;
+import com.weibo.api.motan.exception.MotanServiceException;
+import com.weibo.api.motan.rpc.DefaultResponse;
+import com.weibo.api.motan.rpc.Request;
+import com.weibo.api.motan.rpc.Response;
+import com.weibo.api.motan.rpc.URL;
+import com.weibo.api.motan.transport.AbstractPoolClient;
+import com.weibo.api.motan.transport.Channel;
+import com.weibo.api.motan.transport.TransportException;
+import com.weibo.api.motan.util.LoggerUtil;
+import com.weibo.api.motan.util.MotanFrameworkUtil;
+import com.weibo.api.motan.util.StatisticCallback;
+import com.weibo.api.motan.util.StatsUtil;
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import org.apache.commons.pool.BasePoolableObjectFactory;
+
+import java.util.Map;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * <pre>
+ * 		netty client 相关
+ * 			1)  timeout 设置 （connecttimeout，sotimeout, application timeout）
+ * 			2） 线程池设置
+ *  		3） 最大连接池设置
+ * 			4） 最大消息队列设置 (netty channel内部: writeQueue)
+ * 			5） 最大返回数据包设置
+ * 			6） RPC 的测试的时候，需要非常关注 OOM的问题
+ * </pre>
+ */
+public class Netty4Client extends AbstractPoolClient implements StatisticCallback {
+    // 回收过期任务
+    private static ScheduledExecutorService scheduledExecutor = Executors.newScheduledThreadPool(4);
+
+    // 异步的request，需要注册callback future
+    // 触发remove的操作有： 1) service的返回结果处理。 2) timeout thread cancel
+    protected ConcurrentMap<Long, NettyResponseFuture> callbackMap = new ConcurrentHashMap<Long, NettyResponseFuture>();
+
+    private ScheduledFuture<?> timeMonitorFuture = null;
+
+
+    // 连续失败次数
+    private AtomicLong errorCount = new AtomicLong(0);
+    // 最大连接数
+    private int maxClientConnection = 0;
+
+    private Bootstrap bootstrap;
+
+    public Netty4Client(URL url) {
+        super(url);
+
+        maxClientConnection = url.getIntParameter(URLParamType.maxClientConnection.getName(),
+                URLParamType.maxClientConnection.getIntValue());
+
+        timeMonitorFuture = scheduledExecutor.scheduleWithFixedDelay(
+                new TimeoutMonitor("timeout_monitor_" + url.getHost() + "_" + url.getPort()),
+                MotanConstants.NETTY_TIMEOUT_TIMER_PERIOD, MotanConstants.NETTY_TIMEOUT_TIMER_PERIOD,
+                TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public Response request(Request request) throws TransportException {
+        if (!isAvailable()) {
+            throw new MotanServiceException("NettyChannel is unavaliable: url=" + url.getUri()
+                    + MotanFrameworkUtil.toString(request));
+        }
+        boolean async = url.getMethodParameter(request.getMethodName(), request.getParamtersDesc()
+                , URLParamType.async.getName(), URLParamType.async.getBooleanValue());
+        return request(request, async);
+    }
+
+    @Override
+    public void heartbeat(Request request) {
+        // 如果节点还没有初始化或者节点已经被close掉了，那么heartbeat也不需要进行了
+        if (state.isUnInitState() || state.isCloseState()) {
+            LoggerUtil.warn("NettyClient heartbeat Error: state={} url={}", state.name(), url.getUri());
+            return;
+        }
+
+        LoggerUtil.info("NettyClient heartbeat request: url={}", url.getUri());
+
+        try {
+            // async request后，如果service is
+            // available，那么将会自动把该client设置成可用
+            request(request, true);
+        } catch (Exception e) {
+            LoggerUtil.error("NettyClient heartbeat Error: url=" + url.getUri(), e);
+        }
+    }
+
+    /**
+     * 请求remote service
+     * <p>
+     * <pre>
+     * 		1)  get connection from pool
+     * 		2)  async requset
+     * 		3)  return connection to pool
+     * 		4)  check if async return response, true: return ResponseFuture;  false: return result
+     * </pre>
+     *
+     * @param request
+     * @param async
+     * @return
+     * @throws TransportException
+     */
+    private Response request(Request request, boolean async) throws TransportException {
+        Channel channel = null;
+
+        Response response = null;
+
+        try {
+            // return channel or throw exception(timeout or connection_fail)
+            channel = borrowObject();
+
+            if (channel == null) {
+                LoggerUtil.error("NettyClient borrowObject null: url=" + url.getUri() + " "
+                        + MotanFrameworkUtil.toString(request));
+                return null;
+            }
+
+            // async request
+            response = channel.request(request);
+            // return channel to pool
+            returnObject(channel);
+        } catch (Exception e) {
+            LoggerUtil.error(
+                    "NettyClient request Error: url=" + url.getUri() + " " + MotanFrameworkUtil.toString(request), e);
+            //TODO 对特定的异常回收channel
+            invalidateObject(channel);
+
+            if (e instanceof MotanAbstractException) {
+                throw (MotanAbstractException) e;
+            } else {
+                throw new MotanServiceException("NettyClient request Error: url=" + url.getUri() + " "
+                        + MotanFrameworkUtil.toString(request), e);
+            }
+        }
+
+        // aysnc or sync result
+        response = asyncResponse(response, async);
+
+        return response;
+    }
+
+    /**
+     * 如果async是false，那么同步获取response的数据
+     *
+     * @param response
+     * @param async
+     * @return
+     */
+    private Response asyncResponse(Response response, boolean async) {
+        if (async || !(response instanceof NettyResponseFuture)) {
+            return response;
+        }
+
+        return new DefaultResponse(response);
+    }
+
+    @Override
+    public synchronized boolean open() {
+        if (isAvailable()) {
+            LoggerUtil.warn("NettyServer ServerChannel already Opened: url=" + url);
+            return true;
+        }
+
+        // 初始化netty client bootstrap
+        initClientBootstrap();
+
+        // 初始化连接池
+        initPool();
+
+        LoggerUtil.info("NettyClient finish Open: url={}", url);
+
+        // 注册统计回调
+        StatsUtil.registryStatisticCallback(this);
+
+        // 设置可用状态
+        state = ChannelState.ALIVE;
+        return state.isAliveState();
+    }
+
+    /**
+     * 初始化 netty clientBootstrap
+     */
+    private void initClientBootstrap() {
+        bootstrap = new Bootstrap();
+
+        NioEventLoopGroup group = new NioEventLoopGroup();
+        bootstrap.group(group).channel(NioSocketChannel.class).handler(new Netty4ClientInitializer(url, codec, this));
+
+        bootstrap.option(ChannelOption.TCP_NODELAY, true);
+        bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
+
+		/* 实际上，极端情况下，connectTimeout会达到500ms，因为netty nio的实现中，是依赖BossThread来控制超时，
+         如果为了严格意义的timeout，那么需要应用端进行控制。
+		 */
+        int timeout = getUrl().getIntParameter(URLParamType.requestTimeout.getName(), URLParamType.requestTimeout.getIntValue());
+        if (timeout <= 0) {
+            throw new MotanFrameworkException("NettyClient init Error: timeout(" + timeout + ") <= 0 is forbid.",
+                    MotanErrorMsgConstant.FRAMEWORK_INIT_ERROR);
+        }
+        bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, timeout);
+    }
+
+    @Override
+    public synchronized void close() {
+        close(0);
+    }
+
+    /**
+     * 目前close不支持timeout的概念
+     */
+    @Override
+    public synchronized void close(int timeout) {
+        if (state.isCloseState()) {
+            LoggerUtil.info("NettyClient close fail: already close, url={}", url.getUri());
+            return;
+        }
+
+        // 如果当前nettyClient还没有初始化，那么就没有close的理由。
+        if (state.isUnInitState()) {
+            LoggerUtil.info("NettyClient close Fail: don't need to close because node is unInit state: url={}",
+                    url.getUri());
+            return;
+        }
+
+        try {
+            // 取消定期的回收任务
+            timeMonitorFuture.cancel(true);
+            // 关闭连接池
+            pool.close();
+            // 清空callback
+            callbackMap.clear();
+
+            // 设置close状态
+            state = ChannelState.CLOSE;
+            // 解除统计回调的注册
+            StatsUtil.unRegistryStatisticCallback(this);
+            LoggerUtil.info("NettyClient close Success: url={}", url.getUri());
+        } catch (Exception e) {
+            LoggerUtil.error("NettyClient close Error: url=" + url.getUri(), e);
+        }
+
+    }
+
+    @Override
+    public boolean isClosed() {
+        return state.isCloseState();
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return state.isAliveState();
+    }
+
+    @Override
+    public URL getUrl() {
+        return url;
+    }
+
+    /**
+     * connection factory
+     */
+    @Override
+    protected BasePoolableObjectFactory createChannelFactory() {
+        return new NettyChannelFactory(this);
+    }
+
+    /**
+     * 增加调用失败的次数：
+     * <p>
+     * <pre>
+     * 	 	如果连续失败的次数 >= maxClientConnection, 那么把client设置成不可用状态
+     * </pre>
+     */
+    void incrErrorCount() {
+        long count = errorCount.incrementAndGet();
+
+        // 如果节点是可用状态，同时当前连续失败的次数超过限制maxClientConnection次，那么把该节点标示为不可用
+        if (count >= maxClientConnection && state.isAliveState()) {
+            synchronized (this) {
+                count = errorCount.longValue();
+
+                if (count >= maxClientConnection && state.isAliveState()) {
+                    LoggerUtil.error("NettyClient unavailable Error: url=" + url.getIdentity() + " "
+                            + url.getServerPortStr());
+                    state = ChannelState.UNALIVE;
+                }
+            }
+        }
+    }
+
+    /**
+     * 重置调用失败的计数 ：
+     * <p>
+     * <pre>
+     * 把节点设置成可用
+     * </pre>
+     */
+    void resetErrorCount() {
+        errorCount.set(0);
+
+        if (state.isAliveState()) {
+            return;
+        }
+
+        synchronized (this) {
+            if (state.isAliveState()) {
+                return;
+            }
+
+            // 如果节点是unalive才进行设置，而如果是 close 或者 uninit，那么直接忽略
+            if (state.isUnAliveState()) {
+                long count = errorCount.longValue();
+
+                // 过程中有其他并发更新errorCount的，因此这里需要进行一次判断
+                if (count < maxClientConnection) {
+                    state = ChannelState.ALIVE;
+                    LoggerUtil.info("NettyClient recover available: url=" + url.getIdentity() + " "
+                            + url.getServerPortStr());
+                }
+            }
+        }
+    }
+
+    /**
+     * 注册回调的resposne
+     * <p>
+     * <pre>
+     *
+     * 		进行最大的请求并发数的控制，如果超过NETTY_CLIENT_MAX_REQUEST的话，那么throw reject exception
+     *
+     * </pre>
+     *
+     * @param requestId
+     * @param nettyResponseFuture
+     * @throws MotanServiceException
+     */
+    public void registerCallback(long requestId, NettyResponseFuture nettyResponseFuture) {
+        if (this.callbackMap.size() >= MotanConstants.NETTY_CLIENT_MAX_REQUEST) {
+            // reject request, prevent from OutOfMemoryError
+            throw new MotanServiceException("NettyClient over of max concurrent request, drop request, url: "
+                    + url.getUri() + " requestId=" + requestId, MotanErrorMsgConstant.SERVICE_REJECT);
+        }
+
+        this.callbackMap.put(requestId, nettyResponseFuture);
+    }
+
+    /**
+     * 统计回调接口
+     */
+    @Override
+    public String statisticCallback() {
+        //避免消息泛滥，如果节点是可用状态，并且堆积的请求不超过100的话，那么就不记录log了
+        if (isAvailable() && callbackMap.size() < 100) {
+            return null;
+        }
+
+        return String.format("identity: %s available: %s concurrent_count: %s", url.getIdentity(), isAvailable(),
+                callbackMap.size());
+    }
+
+    /**
+     * 移除回调的response
+     *
+     * @param requestId
+     * @return
+     */
+    public NettyResponseFuture removeCallback(long requestId) {
+        return callbackMap.remove(requestId);
+    }
+
+    public Bootstrap getBootstrap() {
+        return bootstrap;
+    }
+
+    /**
+     * 回收超时任务
+     *
+     * @author maijunsheng
+     */
+    class TimeoutMonitor implements Runnable {
+        private String name;
+
+        public TimeoutMonitor(String name) {
+            this.name = name;
+        }
+
+        public void run() {
+
+            long currentTime = System.currentTimeMillis();
+
+            for (Map.Entry<Long, NettyResponseFuture> entry : callbackMap.entrySet()) {
+                try {
+                    NettyResponseFuture future = entry.getValue();
+                    if (future.getCreateTime() + future.getTimeout() < currentTime) {
+                        // timeout: remove from callback list, and then cancel
+                        removeCallback(entry.getKey());
+                        future.cancel();
+                    }
+                } catch (Exception e) {
+                    LoggerUtil.error(
+                            name + " clear timeout future Error: uri=" + url.getUri() + " requestId=" + entry.getKey(),
+                            e);
+                }
+            }
+        }
+    }
+}

--- a/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/client/Netty4ClientHandler.java
+++ b/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/client/Netty4ClientHandler.java
@@ -1,0 +1,37 @@
+package com.weibo.api.motan.transport.netty4.client;
+
+import com.weibo.api.motan.rpc.Response;
+import com.weibo.api.motan.util.LoggerUtil;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+/**
+ * Created by guohang.bao on 16/5/18.
+ */
+public class Netty4ClientHandler extends SimpleChannelInboundHandler<Response> {
+
+    private Netty4Client client;
+
+    public Netty4ClientHandler(Netty4Client client) {
+        this.client = client;
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, Response response) throws Exception {
+
+        NettyResponseFuture responseFuture = client.removeCallback(response.getRequestId());
+
+        if (responseFuture == null) {
+            LoggerUtil.warn(
+                    "NettyClient has response from server, but resonseFuture not exist,  requestId={}",
+                    response.getRequestId());
+            return;
+        }
+
+        if (response.getException() != null) {
+            responseFuture.onFailure(response);
+        } else {
+            responseFuture.onSuccess(response);
+        }
+    }
+}

--- a/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/client/Netty4ClientInitializer.java
+++ b/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/client/Netty4ClientInitializer.java
@@ -1,0 +1,40 @@
+package com.weibo.api.motan.transport.netty4.client;
+
+import com.weibo.api.motan.codec.Codec;
+import com.weibo.api.motan.common.URLParamType;
+import com.weibo.api.motan.rpc.URL;
+import com.weibo.api.motan.transport.netty4.Netty4Decoder;
+import com.weibo.api.motan.transport.netty4.Netty4Encoder;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+
+/**
+ * Created by guohang.bao on 16/5/18.
+ */
+public class Netty4ClientInitializer extends ChannelInitializer<SocketChannel> {
+
+    private URL url;
+
+    private Codec codec;
+
+    private Netty4Client client;
+
+    public Netty4ClientInitializer(URL url, Codec codec, Netty4Client client) {
+        this.url = url;
+        this.codec = codec;
+        this.client = client;
+    }
+
+    @Override
+    protected void initChannel(SocketChannel ch) throws Exception {
+        ChannelPipeline p = ch.pipeline();
+        // 最大响应包限制
+        int maxContentLength = url.getIntParameter(URLParamType.maxContentLength.getName(),
+                URLParamType.maxContentLength.getIntValue());
+        p.addLast("decoder", new Netty4Decoder(codec, client, maxContentLength));
+        p.addLast("encoder", new Netty4Encoder(codec, client));
+        p.addLast("handler", new Netty4ClientHandler(client));
+
+    }
+}

--- a/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/client/NettyChannel.java
+++ b/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/client/NettyChannel.java
@@ -1,0 +1,207 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.weibo.api.motan.transport.netty4.client;
+
+import com.weibo.api.motan.common.ChannelState;
+import com.weibo.api.motan.common.URLParamType;
+import com.weibo.api.motan.exception.MotanErrorMsgConstant;
+import com.weibo.api.motan.exception.MotanFrameworkException;
+import com.weibo.api.motan.exception.MotanServiceException;
+import com.weibo.api.motan.rpc.*;
+import com.weibo.api.motan.transport.TransportException;
+import com.weibo.api.motan.util.ExceptionUtil;
+import com.weibo.api.motan.util.LoggerUtil;
+import com.weibo.api.motan.util.MotanFrameworkUtil;
+import io.netty.channel.ChannelFuture;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author maijunsheng
+ * @version 创建时间：2013-5-31
+ * 
+ */
+public class NettyChannel implements com.weibo.api.motan.transport.Channel {
+	private volatile ChannelState state = ChannelState.UNINIT;
+
+	private Netty4Client nettyClient;
+
+	private io.netty.channel.Channel channel = null;
+
+	private InetSocketAddress remoteAddress = null;
+	private InetSocketAddress localAddress = null;
+
+	public NettyChannel(Netty4Client nettyClient) {
+		this.nettyClient = nettyClient;
+		this.remoteAddress = new InetSocketAddress(nettyClient.getUrl().getHost(), nettyClient.getUrl().getPort());
+	}
+
+	@Override
+	public Response request(Request request) throws TransportException {
+	    int timeout = nettyClient.getUrl().getMethodParameter(request.getMethodName(), request.getParamtersDesc(),
+	            URLParamType.requestTimeout.getName(), URLParamType.requestTimeout.getIntValue());
+		if (timeout <= 0) {
+               throw new MotanFrameworkException("Netty4Client init Error: timeout(" + timeout + ") <= 0 is forbid.",
+                       MotanErrorMsgConstant.FRAMEWORK_INIT_ERROR);
+           }
+		NettyResponseFuture response = new NettyResponseFuture(request, timeout, this.nettyClient);
+		this.nettyClient.registerCallback(request.getRequestId(), response);
+
+		ChannelFuture writeFuture = this.channel.writeAndFlush(request);
+
+		boolean result = writeFuture.awaitUninterruptibly(timeout, TimeUnit.SECONDS);
+
+		if (result && writeFuture.isSuccess()) {
+			response.addListener(new FutureListener() {
+				@Override
+				public void operationComplete(Future future) throws Exception {
+					if (future.isSuccess() || (future.isDone() && ExceptionUtil.isBizException(future.getException()))) {
+						// 成功的调用 
+						nettyClient.resetErrorCount();
+					} else {
+						// 失败的调用 
+						nettyClient.incrErrorCount();
+					}
+				}
+			});
+			return response;
+		}
+
+		writeFuture.cancel(true);
+		response = this.nettyClient.removeCallback(request.getRequestId());
+
+		if (response != null) {
+			response.cancel();
+		}
+
+		// 失败的调用 
+		nettyClient.incrErrorCount();
+
+		if (writeFuture.cause() != null) {
+			throw new MotanServiceException("NettyChannel send request to server Error: url="
+					+ nettyClient.getUrl().getUri() + " local=" + localAddress + " "
+					+ MotanFrameworkUtil.toString(request), writeFuture.cause());
+		} else {
+			throw new MotanServiceException("NettyChannel send request to server Timeout: url="
+					+ nettyClient.getUrl().getUri() + " local=" + localAddress + " "
+					+ MotanFrameworkUtil.toString(request));
+		}
+	}
+
+	@Override
+	public synchronized boolean open() {
+		if (isAvailable()) {
+			LoggerUtil.warn("the channel already open, local: " + localAddress + " remote: " + remoteAddress + " url: "
+					+ nettyClient.getUrl().getUri());
+			return true;
+		}
+
+		try {
+			ChannelFuture channelFuture = nettyClient.getBootstrap().connect(
+					new InetSocketAddress(nettyClient.getUrl().getHost(), nettyClient.getUrl().getPort()));
+
+			long start = System.currentTimeMillis();
+
+			int timeout = nettyClient.getUrl().getIntParameter(URLParamType.connectTimeout.getName(), URLParamType.connectTimeout.getIntValue());
+			if (timeout <= 0) {
+	            throw new MotanFrameworkException("Netty4Client init Error: timeout(" + timeout + ") <= 0 is forbid.",
+	                    MotanErrorMsgConstant.FRAMEWORK_INIT_ERROR);
+			}
+			// 不去依赖于connectTimeout
+			boolean result = channelFuture.awaitUninterruptibly(timeout, TimeUnit.MILLISECONDS);
+            boolean success = channelFuture.isSuccess();
+
+			if (result && success) {
+				channel = channelFuture.channel();
+				if (channel.localAddress() != null && channel.localAddress() instanceof InetSocketAddress) {
+					localAddress = (InetSocketAddress) channel.localAddress();
+				}
+
+				state = ChannelState.ALIVE;
+				return true;
+			}
+            boolean connected = false;
+            if(channelFuture.channel() != null){
+                connected = channelFuture.channel().isOpen();
+            }
+
+			if (channelFuture.cause() != null) {
+				channelFuture.cancel(true);
+				throw new MotanServiceException("NettyChannel failed to connect to server, url: "
+						+ nettyClient.getUrl().getUri()+ ", result: " + result + ", success: " + success + ", connected: " + connected, channelFuture.cause());
+			} else {
+				channelFuture.cancel(true);
+                throw new MotanServiceException("NettyChannel connect to server timeout url: "
+                        + nettyClient.getUrl().getUri() + ", cost: " + (System.currentTimeMillis() - start) + ", result: " + result + ", success: " + success + ", connected: " + connected);
+            }
+		} catch (MotanServiceException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new MotanServiceException("NettyChannel failed to connect to server, url: "
+					+ nettyClient.getUrl().getUri(), e);
+		} finally {
+			if (!state.isAliveState()) {
+				nettyClient.incrErrorCount();
+			}
+		}
+	}
+
+	@Override
+	public synchronized void close() {
+		close(0);
+	}
+
+	@Override
+	public synchronized void close(int timeout) {
+		try {
+			if (channel != null) {
+				channel.close();
+			}
+
+			state = ChannelState.CLOSE;
+		} catch (Exception e) {
+			LoggerUtil
+					.error("NettyChannel close Error: " + nettyClient.getUrl().getUri() + " local=" + localAddress, e);
+		}
+	}
+
+	@Override
+	public InetSocketAddress getLocalAddress() {
+		return localAddress;
+	}
+
+	@Override
+	public InetSocketAddress getRemoteAddress() {
+		return remoteAddress;
+	}
+
+	@Override
+	public boolean isClosed() {
+		return state.isCloseState();
+	}
+
+	@Override
+	public boolean isAvailable() {
+		return state.isAliveState();
+	}
+
+	@Override
+	public URL getUrl() {
+		return nettyClient.getUrl();
+	}
+}

--- a/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/client/NettyChannelFactory.java
+++ b/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/client/NettyChannelFactory.java
@@ -1,0 +1,100 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.weibo.api.motan.transport.netty4.client;
+
+import com.weibo.api.motan.rpc.URL;
+import com.weibo.api.motan.util.LoggerUtil;
+import org.apache.commons.pool.BasePoolableObjectFactory;
+
+/**
+ * @author maijunsheng
+ * @version 创建时间：2013-5-31
+ * 
+ */
+public class NettyChannelFactory extends BasePoolableObjectFactory {
+	private String factoryName = "";
+	private Netty4Client nettyClient;
+
+	public NettyChannelFactory(Netty4Client nettyClient) {
+		super();
+
+		this.nettyClient = nettyClient;
+		this.factoryName = "NettyChannelFactory_" + nettyClient.getUrl().getHost() + "_"
+				+ nettyClient.getUrl().getPort();
+	}
+
+	public String getFactoryName() {
+		return factoryName;
+	}
+
+	@Override
+	public String toString() {
+		return factoryName;
+	}
+
+	@Override
+	public Object makeObject() throws Exception {
+		NettyChannel nettyChannel = new NettyChannel(nettyClient);
+		nettyChannel.open();
+
+		return nettyChannel;
+	}
+
+	@Override
+	public void destroyObject(final Object obj) throws Exception {
+		if (obj instanceof NettyChannel) {
+			NettyChannel client = (NettyChannel) obj;
+			URL url = nettyClient.getUrl();
+
+			try {
+				client.close();
+
+				LoggerUtil.info(factoryName + " client disconnect Success: " + url.getUri());
+			} catch (Exception e) {
+				LoggerUtil.error(factoryName + " client disconnect Error: " + url.getUri(), e);
+			}
+		}
+	}
+
+	@Override
+	public boolean validateObject(final Object obj) {
+		if (obj instanceof NettyChannel) {
+			final NettyChannel client = (NettyChannel) obj;
+			try {
+				return client.isAvailable();
+			} catch (final Exception e) {
+				return false;
+			}
+		} else {
+			return false;
+		}
+	}
+
+	@Override
+	public void activateObject(Object obj) throws Exception {
+		if (obj instanceof NettyChannel) {
+			final NettyChannel client = (NettyChannel) obj;
+			if (!client.isAvailable()) {
+				client.open();
+			}
+		}
+	}
+
+	@Override
+	public void passivateObject(Object obj) throws Exception {
+	}
+}

--- a/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/client/NettyResponseFuture.java
+++ b/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/client/NettyResponseFuture.java
@@ -1,0 +1,321 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.weibo.api.motan.transport.netty4.client;
+
+import com.weibo.api.motan.common.FutureState;
+import com.weibo.api.motan.exception.MotanErrorMsgConstant;
+import com.weibo.api.motan.exception.MotanServiceException;
+import com.weibo.api.motan.protocol.rpc.RpcProtocolVersion;
+import com.weibo.api.motan.rpc.Future;
+import com.weibo.api.motan.rpc.FutureListener;
+import com.weibo.api.motan.rpc.Request;
+import com.weibo.api.motan.rpc.Response;
+import com.weibo.api.motan.transport.Channel;
+import com.weibo.api.motan.util.LoggerUtil;
+import com.weibo.api.motan.util.MotanFrameworkUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * netty response
+ * 
+ * <pre>
+ * 		1） getValue() :  
+ * 
+ * 			if (request is timeout or request is cancel or get exception)
+ * 				 throw exception; 
+ * 			else 
+ * 				 return value;
+ * 
+ * 		2） getException() :
+ * 		
+ * 			if (task is doing) :
+ * 				 return null
+ * 			if (task is done and get exception):
+ * 				return exception
+ * 
+ * </pre>
+ * 
+ * @author maijunsheng
+ * @version 创建时间：2013-5-31
+ * 
+ */
+public class NettyResponseFuture implements Response, Future {
+	private volatile FutureState state = FutureState.DOING;
+
+	private Object lock = new Object();
+
+	private Object result = null;
+	private Exception exception = null;
+
+	private long createTime = System.currentTimeMillis();
+	private int timeout = 0;
+	private long processTime = 0;
+
+	private Request request;
+	private List<FutureListener> listeners;
+	private Channel channel;
+
+	public NettyResponseFuture(Request requestObj, int timeout, Channel channel) {
+		this.request = requestObj;
+		this.timeout = timeout;
+		this.channel = channel;
+	}
+
+	public void onSuccess(Response response) {
+		this.result = response.getValue();
+		this.processTime = response.getProcessTime();
+
+		done();
+	}
+
+	public void onFailure(Response response) {
+		this.exception = response.getException();
+		this.processTime = response.getProcessTime();
+
+		done();
+	}
+
+	@Override
+	public Object getValue() {
+		synchronized (lock) {
+			if (!isDoing()) {
+				return getValueOrThrowable();
+			}
+
+			if (timeout <= 0) {
+				try {
+					lock.wait();
+				} catch (Exception e) {
+					cancel(new MotanServiceException("NettyResponseFuture getValue InterruptedException : "
+							+ MotanFrameworkUtil.toString(request) + " cost="
+							+ (System.currentTimeMillis() - createTime), e));
+				}
+
+				// don't need to notifylisteners, because onSuccess or
+				// onFailure or cancel method already call notifylisteners
+				return getValueOrThrowable();
+			} else {
+				long waitTime = timeout - (System.currentTimeMillis() - createTime);
+
+				if (waitTime > 0) {
+					for (;;) {
+						try {
+							lock.wait(waitTime);
+						} catch (InterruptedException e) {
+						}
+
+						if (!isDoing()) {
+							break;
+						} else {
+							waitTime = timeout - (System.currentTimeMillis() - createTime);
+							if (waitTime <= 0) {
+								break;
+							}
+						}
+					}
+				}
+
+				if (isDoing()) {
+					timeoutSoCancel();
+				}
+			}
+			return getValueOrThrowable();
+		}
+	}
+
+	@Override
+	public Exception getException() {
+		return exception;
+	}
+
+	@Override
+	public boolean cancel() {
+		Exception e = new MotanServiceException("NettyResponseFuture task cancel: serverPort="
+				+ channel.getUrl().getServerPortStr() + " " + MotanFrameworkUtil.toString(request) + " cost="
+				+ (System.currentTimeMillis() - createTime));
+		return cancel(e);
+	}
+	
+	private boolean cancel(Exception e) {
+		synchronized (lock) {
+			if (!isDoing()) {
+				return false;
+			}
+
+			state = FutureState.CANCELLED;
+			exception = e;
+			lock.notifyAll();
+		}
+
+		notifyListeners();
+		return true;
+	}
+
+	@Override
+	public boolean isCancelled() {
+		return state.isCancelledState();
+	}
+
+	@Override
+	public boolean isDone() {
+		return state.isDoneState();
+	}
+
+	@Override
+	public boolean isSuccess() {
+		return isDone() && (exception == null);
+	}
+
+	@Override
+	public void addListener(FutureListener listener) {
+		if (listener == null) {
+			throw new NullPointerException("FutureListener is null");
+		}
+
+		boolean notifyNow = false;
+		synchronized (lock) {
+			if (!isDoing()) {
+				// is success, failure, timeout or cancel, don't add into
+				// listeners, just notify
+				notifyNow = true;
+			} else {
+				if (listeners == null) {
+					listeners = new ArrayList<FutureListener>(1);
+				}
+
+				listeners.add(listener);
+			}
+		}
+
+		if (notifyNow) {
+			notifyListener(listener);
+		}
+	}
+
+	public long getCreateTime() {
+		return createTime;
+	}
+
+	public Object getRequestObj() {
+		return request;
+	}
+
+	public FutureState getState() {
+		return state;
+	}
+
+	private void timeoutSoCancel() {
+		this.processTime = System.currentTimeMillis() - createTime;
+
+		synchronized (lock) {
+			if (!isDoing()) {
+				return;
+			}
+			
+			state = FutureState.CANCELLED;
+			exception = new MotanServiceException("NettyResponseFuture request timeout: serverPort="
+					+ channel.getUrl().getServerPortStr() + " " + MotanFrameworkUtil.toString(request) + " cost="
+					+ (System.currentTimeMillis() - createTime), MotanErrorMsgConstant.SERVICE_TIMEOUT);
+			
+			lock.notifyAll();
+		}
+
+		notifyListeners();
+	}
+
+	private void notifyListeners() {
+		if (listeners != null) {
+			for (FutureListener listener : listeners) {
+				notifyListener(listener);
+			}
+		}
+	}
+
+	private void notifyListener(FutureListener listener) {
+		try {
+			listener.operationComplete(this);
+		} catch (Throwable t) {
+			LoggerUtil.error("NettyResponseFuture notifyListener Error: " + listener.getClass().getSimpleName(), t);
+		}
+	}
+
+	private boolean isDoing() {
+		return state.isDoingState();
+	}
+
+	private boolean done() {
+		synchronized (lock) {
+			if (!isDoing()) {
+				return false;
+			}
+
+			state = FutureState.DONE;
+			lock.notifyAll();
+		}
+
+		notifyListeners();
+		return true;
+	}
+
+	public long getRequestId() {
+		return this.request.getRequestId();
+	}
+
+	private Object getValueOrThrowable() {
+		if (exception != null) {
+			throw (exception instanceof RuntimeException) ? (RuntimeException) exception : new MotanServiceException(
+					exception.getMessage(), exception);
+		}
+
+		return result;
+	}
+
+	@Override
+	public long getProcessTime() {
+		return processTime;
+	}
+
+	@Override
+	public void setProcessTime(long time) {
+		this.processTime = time;
+	}
+	
+	public int getTimeout() {
+	    return timeout;
+	}
+
+    @Override
+    public Map<String, String> getAttachments() {
+        // 不需要使用
+        return Collections.EMPTY_MAP;
+    }
+
+    @Override
+    public void setAttachment(String key, String value) {}
+
+    @Override
+    public void setRpcProtocolVersion(byte rpcProtocolVersion) {}
+
+    @Override
+    public byte getRpcProtocolVersion() {
+        return RpcProtocolVersion.VERSION_1.getVersion();
+    }
+}

--- a/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/server/Netty4Server.java
+++ b/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/server/Netty4Server.java
@@ -1,0 +1,151 @@
+package com.weibo.api.motan.transport.netty4.server;
+
+import com.weibo.api.motan.common.ChannelState;
+import com.weibo.api.motan.exception.MotanFrameworkException;
+import com.weibo.api.motan.rpc.Request;
+import com.weibo.api.motan.rpc.Response;
+import com.weibo.api.motan.rpc.URL;
+import com.weibo.api.motan.transport.AbstractServer;
+import com.weibo.api.motan.transport.MessageHandler;
+import com.weibo.api.motan.transport.TransportException;
+import com.weibo.api.motan.util.LoggerUtil;
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+
+/**
+ * Created by guohang.bao on 16/5/17.
+ */
+public class Netty4Server extends AbstractServer {
+
+    protected volatile ChannelState state = ChannelState.UNINIT;
+
+    private ServerBootstrap bootstrap = new ServerBootstrap();
+
+    private MessageHandler messageHandler;
+
+    private EventLoopGroup bossGroup;
+    private EventLoopGroup workerGroup;
+
+    private Channel serverChannel;
+
+    private Netty4ServerInitializer serverInitializer;
+
+    public Netty4Server(URL url, MessageHandler messageHandler) {
+        super(url);
+        this.messageHandler = messageHandler;
+    }
+
+    @Override
+    public boolean isBound() {
+        return serverChannel != null && serverChannel.isActive();
+    }
+
+    @Override
+    public Response request(Request request) throws TransportException {
+        throw new MotanFrameworkException("NettyServer request(Request request) method unsupport: url: " + url);
+    }
+
+    @Override
+    public boolean open() {
+        if (isAvailable()) {
+            LoggerUtil.warn("NettyServer ServerChannel already Open: url=" + url);
+            return true;
+        }
+
+        LoggerUtil.info("NettyServer ServerChannel start to Open: url=" + url);
+
+
+        new Thread(new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    initServerBootstrap();
+
+                    serverChannel = bootstrap.bind(url.getPort()).sync().channel();
+                    state = ChannelState.ALIVE;
+                    LoggerUtil.info("NettyServer ServerChannel finish Open: url=" + url);
+                    serverChannel.closeFuture().sync();
+                } catch (InterruptedException e) {
+                    LoggerUtil.error("NettyServer open interrupted: url=" + url.getUri(), e);
+                } finally {
+                    close();
+                }
+            }
+        }).start();
+
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            LoggerUtil.error("NettyServer open interrupted: url=" + url.getUri(), e);
+        }
+
+        return state.isAliveState();
+    }
+
+    private synchronized void initServerBootstrap() {
+        bootstrap = new ServerBootstrap();
+
+        bossGroup = new NioEventLoopGroup(1);
+        workerGroup = new NioEventLoopGroup();
+
+        serverInitializer = new Netty4ServerInitializer(this, url, codec, messageHandler);
+        bootstrap.group(bossGroup, workerGroup)
+                .channel(NioServerSocketChannel.class)
+                .childHandler(serverInitializer);
+
+        bootstrap.childOption(ChannelOption.TCP_NODELAY, true)
+                .childOption(ChannelOption.SO_KEEPALIVE, true);
+    }
+
+
+    @Override
+    public void close() {
+        close(0);
+    }
+
+    @Override
+    public void close(int timeout) {
+        if (state.isCloseState()) {
+            LoggerUtil.info("NettyServer close fail: already close, url={}", url.getUri());
+            return;
+        }
+
+        if (state.isUnInitState()) {
+            LoggerUtil.info("NettyServer close Fail: don't need to close because node is unInit state: url={}",
+                    url.getUri());
+            return;
+        }
+
+        try {
+            bossGroup.shutdownGracefully();
+            workerGroup.shutdownGracefully();
+            serverChannel.close();
+            serverInitializer.close();
+            state = ChannelState.CLOSE;
+            LoggerUtil.info("NettyServer close Success: url={}", url.getUri());
+        } catch (Exception e) {
+            LoggerUtil.error("NettyServer close Error: url=" + url.getUri(), e);
+        }
+    }
+
+    @Override
+    public boolean isClosed() {
+        return state.isCloseState();
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return state.isAliveState();
+    }
+
+    @Override
+    public URL getUrl() {
+        return url;
+    }
+
+}

--- a/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/server/Netty4ServerChannelManage.java
+++ b/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/server/Netty4ServerChannelManage.java
@@ -1,0 +1,117 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.weibo.api.motan.transport.netty4.server;
+
+import com.weibo.api.motan.util.LoggerUtil;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * @author guohang
+ */
+@ChannelHandler.Sharable
+public class Netty4ServerChannelManage extends ChannelInboundHandlerAdapter {
+    private ConcurrentMap<String, Channel> channels = new ConcurrentHashMap<String, Channel>();
+
+    private int maxChannel = 0;
+
+    public Netty4ServerChannelManage(int maxChannel) {
+        super();
+        this.maxChannel = maxChannel;
+    }
+
+    @Override
+    public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+        Channel channel = ctx.channel();
+
+        String channelKey = getChannelKey((InetSocketAddress) channel.localAddress(),
+                (InetSocketAddress) channel.remoteAddress());
+
+        if (channels.size() > maxChannel) {
+            // 超过最大连接数限制，直接close连接
+            LoggerUtil.warn("Netty4ServerChannelManage channelConnected channel size out of limit: limit={} current={}",
+                    maxChannel, channels.size());
+
+            channel.close();
+        } else {
+            channels.put(channelKey, channel);
+            ctx.fireChannelRegistered();
+        }
+    }
+
+    @Override
+    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+        Channel channel = ctx.channel();
+
+        String channelKey = getChannelKey((InetSocketAddress) channel.localAddress(),
+                (InetSocketAddress) channel.remoteAddress());
+
+        channels.remove(channelKey);
+        ctx.fireChannelUnregistered();
+    }
+
+    public Map<String, Channel> getChannels() {
+        return channels;
+    }
+
+    /**
+     * close所有的连接
+     */
+    public void close() {
+        for (Channel ch : channels.values()) {
+            try {
+                if (ch != null) {
+                    ch.close();
+                }
+            } catch (Exception e) {
+                LoggerUtil.error("Netty4ServerChannelManage close channel Error: "
+                        + getChannelKey((InetSocketAddress) ch.localAddress(), (InetSocketAddress) ch.remoteAddress()), e);
+            }
+        }
+    }
+
+    /**
+     * remote address + local address 作为连接的唯一标示
+     *
+     * @param local
+     * @param remote
+     * @return
+     */
+    private String getChannelKey(InetSocketAddress local, InetSocketAddress remote) {
+        String key = "";
+        if (local == null || local.getAddress() == null) {
+            key += "null-";
+        } else {
+            key += local.getAddress().getHostAddress() + ":" + local.getPort() + "-";
+        }
+
+        if (remote == null || remote.getAddress() == null) {
+            key += "null";
+        } else {
+            key += remote.getAddress().getHostAddress() + ":" + remote.getPort();
+        }
+
+        return key;
+    }
+}

--- a/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/server/Netty4ServerHandler.java
+++ b/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/server/Netty4ServerHandler.java
@@ -1,0 +1,116 @@
+package com.weibo.api.motan.transport.netty4.server;
+
+import com.weibo.api.motan.common.URLParamType;
+import com.weibo.api.motan.exception.MotanErrorMsgConstant;
+import com.weibo.api.motan.exception.MotanServiceException;
+import com.weibo.api.motan.rpc.DefaultResponse;
+import com.weibo.api.motan.rpc.Request;
+import com.weibo.api.motan.transport.Channel;
+import com.weibo.api.motan.transport.MessageHandler;
+import com.weibo.api.motan.util.LoggerUtil;
+import com.weibo.api.motan.util.NetUtils;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * Created by guohang.bao on 16/5/17.
+ */
+@ChannelHandler.Sharable
+public class Netty4ServerHandler extends SimpleChannelInboundHandler<Request> {
+
+    private ThreadPoolExecutor executor;
+    private MessageHandler messageHandler;
+    private Channel serverChannel;
+
+
+    public Netty4ServerHandler(ThreadPoolExecutor executor, MessageHandler messageHandler, Channel serverChannel) {
+        this.executor = executor;
+        this.messageHandler = messageHandler;
+        this.serverChannel = serverChannel;
+    }
+
+    @Override
+    public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+        LoggerUtil.info("NettyChannelHandler channelRegistered: remote=" + ctx.channel().remoteAddress()
+                + " local=" + ctx.channel().localAddress());
+
+    }
+
+    @Override
+    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+        LoggerUtil.info("NettyChannelHandler channelDisconnected: remote=" + ctx.channel().remoteAddress()
+                + " local=" + ctx.channel().localAddress());
+
+    }
+
+
+    /**
+     * <pre>
+     *  request process: 主要来自于client的请求，需要使用threadPoolExecutor进行处理，避免service message处理比较慢导致iothread被阻塞
+     * </pre>
+     *
+     * @param ctx
+     * @param request
+     */
+    @Override
+    protected void channelRead0(final ChannelHandlerContext ctx, final Request request) throws Exception {
+        request.setAttachment(URLParamType.host.getName(), NetUtils.getHostName(ctx.channel().remoteAddress()));
+
+        final long processStartTime = System.currentTimeMillis();
+
+        // 使用线程池方式处理
+        try {
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    processRequest(ctx, request, processStartTime);
+                }
+            });
+        } catch (RejectedExecutionException rejectException) {
+            DefaultResponse response = new DefaultResponse();
+            response.setRequestId(request.getRequestId());
+            response.setException(new MotanServiceException("process thread pool is full, reject",
+                    MotanErrorMsgConstant.SERVICE_REJECT));
+            response.setProcessTime(System.currentTimeMillis() - processStartTime);
+            ctx.channel().writeAndFlush(response);
+
+            LoggerUtil
+                    .debug("process thread pool is full, reject, active={} poolSize={} corePoolSize={} maxPoolSize={} taskCount={} requestId={}",
+                            executor.getActiveCount(), executor.getPoolSize(),
+                            executor.getCorePoolSize(), executor.getMaximumPoolSize(),
+                            executor.getTaskCount(), request.getRequestId());
+        }
+    }
+
+
+    private void processRequest(ChannelHandlerContext ctx, Request request, long processStartTime) {
+        Object result = messageHandler.handle(serverChannel, request);
+
+        DefaultResponse response = null;
+
+        if (!(result instanceof DefaultResponse)) {
+            response = new DefaultResponse(result);
+        } else {
+            response = (DefaultResponse) result;
+        }
+
+        response.setRequestId(request.getRequestId());
+        response.setProcessTime(System.currentTimeMillis() - processStartTime);
+
+        if (ctx.channel().isOpen()) {
+            ctx.channel().writeAndFlush(response);
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable e) throws Exception {
+        LoggerUtil.error("NettyChannelHandler exceptionCaught: remote=" + ctx.channel().remoteAddress()
+                + " local=" + ctx.channel().localAddress() + " event=" + e.getCause(), e.getCause());
+
+        ctx.channel().close();
+    }
+}

--- a/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/server/Netty4ServerInitializer.java
+++ b/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/server/Netty4ServerInitializer.java
@@ -1,0 +1,107 @@
+package com.weibo.api.motan.transport.netty4.server;
+
+import com.weibo.api.motan.codec.Codec;
+import com.weibo.api.motan.common.MotanConstants;
+import com.weibo.api.motan.common.URLParamType;
+import com.weibo.api.motan.core.DefaultThreadFactory;
+import com.weibo.api.motan.rpc.URL;
+import com.weibo.api.motan.transport.Channel;
+import com.weibo.api.motan.transport.MessageHandler;
+import com.weibo.api.motan.transport.netty4.Netty4Decoder;
+import com.weibo.api.motan.transport.netty4.Netty4Encoder;
+import com.weibo.api.motan.transport.netty4.StandardThreadExecutor;
+import com.weibo.api.motan.util.StatisticCallback;
+import com.weibo.api.motan.util.StatsUtil;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+
+/**
+ * Created by guohang.bao on 16/5/17.
+ */
+public class Netty4ServerInitializer extends ChannelInitializer<SocketChannel> implements StatisticCallback {
+
+    private URL url;
+
+    private Codec codec;
+
+    private Channel client;
+
+    private Netty4ServerChannelManage channelManage;
+
+    private StandardThreadExecutor executor;
+
+    private Netty4ServerHandler serverHandler;
+
+    public Netty4ServerInitializer(Channel client, URL url, Codec codec, MessageHandler messageHandler) {
+        this.url = url;
+        this.codec = codec;
+        this.client = client;
+
+        // 连接数的管理，进行最大连接数的限制
+        int maxServerConnection = url.getIntParameter(URLParamType.maxServerConnection.getName(),
+                URLParamType.maxServerConnection.getIntValue());
+        channelManage = new Netty4ServerChannelManage(maxServerConnection);
+
+        executor = initExecutor();
+
+        serverHandler = new Netty4ServerHandler(executor, messageHandler, client);
+    }
+
+    @Override
+    public void initChannel(SocketChannel ch) {
+        ChannelPipeline p = ch.pipeline();
+
+        p.addLast("channel_manage", channelManage);
+
+        int maxContentLength = url.getIntParameter(URLParamType.maxContentLength.getName(),
+                URLParamType.maxContentLength.getIntValue());
+        p.addLast("decoder", new Netty4Decoder(codec, client, maxContentLength))
+                .addLast("encoder", new Netty4Encoder(codec, client));
+
+        p.addLast("handler", serverHandler);
+
+        StatsUtil.registryStatisticCallback(this);
+    }
+
+    private StandardThreadExecutor initExecutor() {
+        boolean shareChannel = url.getBooleanParameter(URLParamType.shareChannel.getName(),
+                URLParamType.shareChannel.getBooleanValue());
+        int workerQueueSize = url.getIntParameter(URLParamType.workerQueueSize.getName(),
+                URLParamType.workerQueueSize.getIntValue());
+
+        int minWorkerThread, maxWorkerThread;
+
+        if (shareChannel) {
+            minWorkerThread = url.getIntParameter(URLParamType.minWorkerThread.getName(),
+                    MotanConstants.NETTY_SHARECHANNEL_MIN_WORKDER);
+            maxWorkerThread = url.getIntParameter(URLParamType.maxWorkerThread.getName(),
+                    MotanConstants.NETTY_SHARECHANNEL_MAX_WORKDER);
+        } else {
+            minWorkerThread = url.getIntParameter(URLParamType.minWorkerThread.getName(),
+                    MotanConstants.NETTY_NOT_SHARECHANNEL_MIN_WORKDER);
+            maxWorkerThread = url.getIntParameter(URLParamType.maxWorkerThread.getName(),
+                    MotanConstants.NETTY_NOT_SHARECHANNEL_MAX_WORKDER);
+        }
+
+        StandardThreadExecutor executor = new StandardThreadExecutor(minWorkerThread, maxWorkerThread, workerQueueSize,
+                new DefaultThreadFactory("NettyServer-" + url.getServerPortStr(), true));
+        executor.prestartAllCoreThreads();
+        return executor;
+    }
+
+    public void close() {
+        channelManage.close();
+        executor.shutdown();
+        StatsUtil.unRegistryStatisticCallback(this);
+    }
+
+    @Override
+    public String statisticCallback() {
+        return String.format(
+                "identity: %s connectionCount: %s taskCount: %s queueCount: %s maxThreadCount: %s maxTaskCount: %s",
+                url.getIdentity(), channelManage.getChannels().size(), executor.getSubmittedTasksCount(),
+                executor.getQueue().size(), executor.getMaximumPoolSize(),
+                executor.getMaxSubmittedTaskCount());
+    }
+}

--- a/motan-transport-netty4/src/main/resources/META-INF/services/com.weibo.api.motan.transport.EndpointFactory
+++ b/motan-transport-netty4/src/main/resources/META-INF/services/com.weibo.api.motan.transport.EndpointFactory
@@ -1,0 +1,17 @@
+#
+#  Copyright 2009-2016 Weibo, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+com.weibo.api.motan.transport.netty4.Netty4EndpointFactory

--- a/motan-transport-netty4/src/test/java/com/weibo/api/motan/transport/netty4/MockDefaultRpcCodec.java
+++ b/motan-transport-netty4/src/test/java/com/weibo/api/motan/transport/netty4/MockDefaultRpcCodec.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.weibo.api.motan.transport.netty4;
+
+import com.weibo.api.motan.codec.AbstractCodec;
+import com.weibo.api.motan.common.MotanConstants;
+import com.weibo.api.motan.core.extension.SpiMeta;
+import com.weibo.api.motan.exception.MotanErrorMsgConstant;
+import com.weibo.api.motan.exception.MotanFrameworkException;
+import com.weibo.api.motan.protocol.rpc.DefaultRpcCodec;
+import com.weibo.api.motan.rpc.DefaultResponse;
+import com.weibo.api.motan.rpc.Response;
+import com.weibo.api.motan.transport.Channel;
+
+import java.io.IOException;
+
+@SpiMeta(name = "mockMotan")
+public class MockDefaultRpcCodec extends AbstractCodec {
+    private DefaultRpcCodec codec = new DefaultRpcCodec();
+
+    private static final byte MASK = 0x07;
+
+    @Override
+    public byte[] encode(Channel channel, Object message) throws IOException {
+        return codec.encode(channel, message);
+    }
+
+    @Override
+    public Object decode(Channel channel, String remoteIp, byte[] buffer) throws IOException {
+        Object result = codec.decode(channel, remoteIp, buffer);
+
+        if (result instanceof Response) {
+            DefaultResponse object = (DefaultResponse) result;
+
+            byte flag = buffer[3];
+            byte dataType = (byte) (flag & MASK);
+            boolean isResponse = (dataType != MotanConstants.FLAG_REQUEST);
+
+            if (object.getException() == null) {
+                if (isResponse && object.getValue().equals("error")) {
+                    DefaultResponse response = (DefaultResponse) object;
+                    response.setException(new MotanFrameworkException("decode error: response dataType not support " + dataType,
+                            MotanErrorMsgConstant.FRAMEWORK_DECODE_ERROR));
+                    return response;
+                } else {
+                    throw new MotanFrameworkException(MotanErrorMsgConstant.FRAMEWORK_DECODE_ERROR);
+                }
+            }
+            return object;
+        }
+
+        return result;
+    }
+}

--- a/motan-transport-netty4/src/test/java/com/weibo/api/motan/transport/netty4/Netty4EndpointFactoryTest.java
+++ b/motan-transport-netty4/src/test/java/com/weibo/api/motan/transport/netty4/Netty4EndpointFactoryTest.java
@@ -1,0 +1,150 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.weibo.api.motan.transport.netty4;
+
+import com.weibo.api.motan.common.URLParamType;
+import com.weibo.api.motan.rpc.URL;
+import com.weibo.api.motan.transport.*;
+import com.weibo.api.motan.transport.support.HeartbeatClientEndpointManager;
+import junit.framework.Assert;
+import junit.framework.TestCase;
+import org.junit.Test;
+
+/**
+ * @author maijunsheng
+ * @version 创建时间：2013-6-19
+ * 
+ */
+public class Netty4EndpointFactoryTest extends TestCase {
+
+    @Test
+    public void testCreateServer() {
+        testNotShareChannel(true);
+        testNotShareChannel(false);
+
+        testShareChannel(true);
+        testShareChannel(false);
+    }
+
+    private void testNotShareChannel(boolean isServer) {
+        Netty4EndpointFactory factory = new Netty4EndpointFactory();
+        MessageHandler handler = new ProviderMessageRouter();
+
+        URL url = new URL("motan", "localhost", 18080, "com.weibo.api.motan.procotol.example.IHello");
+
+        Endpoint endpoint = createEndpoint(url, handler, isServer, factory);
+
+        Assert.assertEquals(endpoint.getUrl().getUri(), url.getUri());
+
+        url = new URL("motan", "localhost", 18081, "com.weibo.api.motan.procotol.example.IHello");
+        endpoint = createEndpoint(url, handler, isServer, factory);
+        Assert.assertEquals(endpoint.getUrl().getUri(), url.getUri());
+
+        Assert.assertTrue(endpoint != createEndpoint(new URL("motan", "localhost", 18081, "com.weibo.api.motan.procotol.example.IHello"),
+                handler, isServer, factory));
+
+        if (isServer) {
+            Assert.assertEquals(factory.getShallServerChannels().size(), 0);
+        }
+
+        if (isServer) {
+            factory.safeReleaseResource((Server) endpoint, url);
+        } else {
+            Assert.assertEquals(((HeartbeatClientEndpointManager) factory.getEndpointManager()).getClients().size(), 3);
+            factory.safeReleaseResource((Client) endpoint, url);
+            Assert.assertEquals(((HeartbeatClientEndpointManager) factory.getEndpointManager()).getClients().size(), 2);
+        }
+    }
+
+    private void testShareChannel(boolean isServer) {
+        Netty4EndpointFactory factory = new Netty4EndpointFactory();
+        MessageHandler handler = new ProviderMessageRouter();
+
+        URL url1 = new URL("motan", "localhost", 18080, "com.weibo.api.motan.procotol.example.IHello");
+        url1.addParameter(URLParamType.shareChannel.getName(), "true");
+
+        Endpoint endpoint1 = createEndpoint(url1, handler, isServer, factory);
+
+        Assert.assertEquals(endpoint1.getUrl().getServerPortStr(), url1.getServerPortStr());
+
+        URL url2 = new URL("motan", "localhost", 18081, "com.weibo.api.motan.protocol.example.IHello1");
+        url2.addParameter(URLParamType.shareChannel.getName(), "true");
+
+        Endpoint endpoint2 = createEndpoint(url2, handler, isServer, factory);
+        Assert.assertEquals(endpoint2.getUrl().getServerPortStr(), url2.getServerPortStr());
+
+        URL url3 = new URL("motan", "localhost", 18081, "com.weibo.api.motan.protocol.example.IHello2");
+        url3.addParameter(URLParamType.shareChannel.getName(), "true");
+
+        Endpoint endpoint3 = createEndpoint(url3, handler, isServer, factory);
+
+        if (isServer) {
+            Assert.assertTrue(endpoint2 == endpoint3);
+        } else {
+            Assert.assertTrue(endpoint2 != endpoint3);
+        }
+
+        URL url4 = new URL("injvm", "localhost", 18081, "com.weibo.api.motan.protocol.example.IHello3");
+        url4.addParameter(URLParamType.shareChannel.getName(), "true");
+        Endpoint endpoint4 = null;
+
+        if (isServer) {
+            try {
+                endpoint4 = createEndpoint(url4, handler, isServer, factory);
+                Assert.assertTrue(false);
+            } catch (Exception e) {
+                Assert.assertTrue(true);
+            }
+        } else {
+            try {
+                endpoint4 = createEndpoint(url4, handler, isServer, factory);
+                Assert.assertTrue(true);
+            } catch (Exception e) {
+                Assert.assertTrue(false);
+            }
+        }
+
+        if (isServer) {
+            Assert.assertEquals(factory.getShallServerChannels().size(), 2);
+        }
+
+        if (isServer) {
+            factory.safeReleaseResource((Server) endpoint1, url1);
+            factory.safeReleaseResource((Server) endpoint2, url2);
+            factory.safeReleaseResource((Server) endpoint3, url3);
+            Assert.assertEquals(factory.getShallServerChannels().size(), 0);
+        } else {
+            Assert.assertEquals(((HeartbeatClientEndpointManager) factory.getEndpointManager()).getClients().size(), 4);
+            factory.safeReleaseResource((Client) endpoint1, url1);
+            Assert.assertEquals(((HeartbeatClientEndpointManager) factory.getEndpointManager()).getClients().size(), 3);
+            factory.safeReleaseResource((Client) endpoint2, url2);
+            Assert.assertEquals(((HeartbeatClientEndpointManager) factory.getEndpointManager()).getClients().size(), 2);
+            factory.safeReleaseResource((Client) endpoint3, url3);
+            Assert.assertEquals(((HeartbeatClientEndpointManager) factory.getEndpointManager()).getClients().size(), 1);
+            factory.safeReleaseResource((Client) endpoint4, url4);
+            Assert.assertEquals(((HeartbeatClientEndpointManager) factory.getEndpointManager()).getClients().size(), 0);
+        }
+    }
+
+    private Endpoint createEndpoint(URL url, MessageHandler messageHandler, boolean isServer, Netty4EndpointFactory factory) {
+        if (isServer) {
+            return factory.createServer(url, messageHandler);
+        } else {
+            return factory.createClient(url);
+        }
+    }
+}

--- a/motan-transport-netty4/src/test/java/com/weibo/api/motan/transport/netty4/Netty4ServerExample.java
+++ b/motan-transport-netty4/src/test/java/com/weibo/api/motan/transport/netty4/Netty4ServerExample.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.weibo.api.motan.transport.netty4;
+
+import com.weibo.api.motan.rpc.DefaultResponse;
+import com.weibo.api.motan.rpc.Request;
+import com.weibo.api.motan.rpc.URL;
+import com.weibo.api.motan.transport.Channel;
+import com.weibo.api.motan.transport.MessageHandler;
+import com.weibo.api.motan.transport.netty4.server.Netty4Server;
+
+/**
+ * @author maijunsheng
+ * @version 创建时间：2013-6-7
+ * 
+ */
+public class Netty4ServerExample {
+    public static void main(String[] args) throws InterruptedException {
+        URL url = new URL("netty", "localhost", 18080, "com.weibo.api.motan.procotol.example.IHello");
+
+        Netty4Server nettyServer = new Netty4Server(url, new MessageHandler() {
+            @Override
+            public Object handle(Channel channel, Object message) {
+                Request request = (Request) message;
+
+                System.out.println("[server] get request: requestId: " + request.getRequestId() + " method: " + request.getMethodName());
+
+                DefaultResponse response = new DefaultResponse();
+                response.setRequestId(request.getRequestId());
+                response.setValue("method: " + request.getMethodName() + " time: " + System.currentTimeMillis());
+
+                return response;
+            }
+        });
+
+        nettyServer.open();
+        System.out.println("~~~~~~~~~~~~~ Server open ~~~~~~~~~~~~~");
+
+        Thread.sleep(100000);
+    }
+}

--- a/motan-transport-netty4/src/test/java/com/weibo/api/motan/transport/netty4/client/Netty4ClientTest.java
+++ b/motan-transport-netty4/src/test/java/com/weibo/api/motan/transport/netty4/client/Netty4ClientTest.java
@@ -1,0 +1,129 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.weibo.api.motan.transport.netty4.client;
+
+import com.weibo.api.motan.common.URLParamType;
+import com.weibo.api.motan.exception.MotanServiceException;
+import com.weibo.api.motan.rpc.*;
+import com.weibo.api.motan.transport.Channel;
+import com.weibo.api.motan.transport.MessageHandler;
+import com.weibo.api.motan.transport.netty4.client.Netty4Client;
+import com.weibo.api.motan.transport.netty4.server.Netty4Server;
+import com.weibo.api.motan.util.RequestIdGenerator;
+import junit.framework.Assert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class Netty4ClientTest {
+
+    private Netty4Server nettyServer;
+    private Netty4Client nettyClient;
+    private DefaultRequest request;
+    private URL url;
+
+    @Before
+    public void setUp() {
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put("requestTimeout", "500");
+
+        url = new URL("netty", "localhost", 18080, "com.weibo.api.motan.procotol.example.IHello", parameters);
+
+        request = new DefaultRequest();
+        request.setRequestId(RequestIdGenerator.getRequestId());
+        request.setInterfaceName("com.weibo.api.motan.procotol.example.IHello");
+        request.setMethodName("hello");
+        request.setParamtersDesc("void");
+
+        nettyServer = new Netty4Server(url, new MessageHandler() {
+            @Override
+            public Object handle(Channel channel, Object message) {
+                Request request = (Request) message;
+                DefaultResponse response = new DefaultResponse();
+                response.setRequestId(request.getRequestId());
+                response.setValue("method: " + request.getMethodName() + " requestId: " + request.getRequestId());
+
+                return response;
+            }
+        });
+
+        nettyServer.open();
+    }
+
+    @After
+    public void tearDown() {
+        nettyClient.close();
+        nettyServer.close();
+    }
+
+    @Test
+    public void testNormal() {
+        nettyClient = new Netty4Client(url);
+        nettyClient.open();
+
+        Response response;
+        try {
+            response = nettyClient.request(request);
+            Object result = response.getValue();
+
+            Assert.assertNotNull(result);
+            Assert.assertEquals("method: " + request.getMethodName() + " requestId: " + request.getRequestId(), result);
+        } catch (MotanServiceException e) {
+            assertTrue(false);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+
+    }
+
+    @Test
+    public void testAbNormal() {
+        // requestTimeout 不可以小于等于0
+        url.addParameter(URLParamType.requestTimeout.getName(), URLParamType.requestTimeout.getValue());
+        nettyClient = new Netty4Client(url);
+        // nettyClient未开启，状态为INIT
+        try {
+            nettyClient.request(request);
+            fail("Netty Client should not be active!");
+        } catch (MotanServiceException e) {
+            assertTrue(true);
+        } catch (Exception e) {
+            assertTrue(false);
+        }
+
+        // 模拟失败连接的次数大于或者等于设置的次数，client期望为不可用
+        url.addParameter(URLParamType.maxClientConnection.getName(), "1");
+        url.addParameter(URLParamType.requestTimeout.getName(), "1");
+        nettyClient = new Netty4Client(url);
+        nettyClient.open();
+        try {
+            nettyClient.request(request);
+        } catch (MotanServiceException e) {
+            assertFalse(nettyClient.isAvailable());
+            nettyClient.resetErrorCount();
+            assertTrue(nettyClient.isAvailable());
+        } catch (Exception e) {
+        }
+
+    }
+
+}

--- a/motan-transport-netty4/src/test/java/com/weibo/api/motan/transport/netty4/server/NettyExampleTest.java
+++ b/motan-transport-netty4/src/test/java/com/weibo/api/motan/transport/netty4/server/NettyExampleTest.java
@@ -1,0 +1,190 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.weibo.api.motan.transport.netty4.server;
+
+import com.weibo.api.motan.codec.Codec;
+import com.weibo.api.motan.common.URLParamType;
+import com.weibo.api.motan.core.extension.ExtensionLoader;
+import com.weibo.api.motan.rpc.DefaultRequest;
+import com.weibo.api.motan.rpc.DefaultResponse;
+import com.weibo.api.motan.rpc.Request;
+import com.weibo.api.motan.rpc.URL;
+import com.weibo.api.motan.transport.Channel;
+import com.weibo.api.motan.transport.MessageHandler;
+import com.weibo.api.motan.transport.netty4.MockDefaultRpcCodec;
+import com.weibo.api.motan.transport.netty4.client.Netty4Client;
+import com.weibo.api.motan.util.RequestIdGenerator;
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author maijunsheng
+ * @version 创建时间：2013-6-3
+ * 
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class NettyExampleTest extends TestCase {
+
+    private static URL url = null;
+
+    static {
+        ExtensionLoader loader = ExtensionLoader.getExtensionLoader(Codec.class);
+        loader.addExtensionClass(MockDefaultRpcCodec.class);
+    }
+
+    @Before
+    public void setUp() {
+        url = new URL("netty", "localhost", 18080, "com.weibo.api.motan.procotol.example.IHello");
+        url.addParameter(URLParamType.codec.getName(), "mockMotan");
+        url.addParameter(URLParamType.requestTimeout.getName(), "2000");
+    }
+
+    @Test
+    public void testNettyEncodeException() throws Exception {
+        Netty4Server nettyServer;
+        nettyServer = new Netty4Server(url, new MessageHandler() {
+            @Override
+            public Object handle(Channel channel, Object message) {
+                Request request = (Request) message;
+                DefaultResponse response = new DefaultResponse();
+                response.setRequestId(request.getRequestId());
+                // 序列化错误
+                response.setValue(new UnSerializableClass());
+                return response;
+            }
+        });
+
+        nettyServer.open();
+        Netty4Client nettyClient = new Netty4Client(url);
+        nettyClient.open();
+
+        DefaultRequest request = new DefaultRequest();
+        request.setRequestId(RequestIdGenerator.getRequestId());
+        request.setInterfaceName(url.getPath());
+        request.setMethodName("helloSerializable");
+        request.setParamtersDesc("com.weibo.api.motan.procotol.example.UnSerializableClass");
+        request.setArguments(new Object[] {new UnSerializableClass()});
+
+        try {
+            nettyClient.request(request);
+            Assert.assertFalse(true);
+        } catch (Exception e) {
+            Assert.assertTrue(true);
+        }
+
+        DefaultRequest request1 = new DefaultRequest();
+        request1.setRequestId(RequestIdGenerator.getRequestId());
+        request1.setInterfaceName(url.getPath());
+        request1.setMethodName("helloSerializable");
+        request1.setParamtersDesc("void");
+        try {
+            nettyClient.request(request1);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("error_code: 20002"));
+
+        } finally {
+            nettyClient.close();
+            nettyServer.close();
+        }
+
+    }
+
+    /**
+     * @throws Exception
+     */
+    @Test
+    public void testNettyRequestDecodeException() throws Exception {
+        Netty4Server nettyServer;
+        nettyServer = new Netty4Server(url, new MessageHandler() {
+            @Override
+            public Object handle(Channel channel, Object message) {
+                Request request = (Request) message;
+                DefaultResponse response = new DefaultResponse();
+                response.setRequestId(request.getRequestId());
+                response.setValue("success");
+                return response;
+            }
+        });
+        nettyServer.open();
+
+        Netty4Client nettyClient = new Netty4Client(url);
+        nettyClient.open();
+
+        DefaultRequest request = new DefaultRequest();
+        request.setRequestId(RequestIdGenerator.getRequestId());
+        request.setInterfaceName(url.getPath());
+        request.setMethodName("hello");
+        request.setParamtersDesc("void");
+
+        try {
+            nettyClient.request(request);
+            Assert.assertTrue(false);
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("framework decode error"));
+        } finally {
+            nettyClient.close();
+            nettyServer.close();
+        }
+    }
+
+    @Test
+    public void testNettyDecodeException() throws Exception {
+
+        Netty4Server nettyServer;
+        nettyServer = new Netty4Server(url, new MessageHandler() {
+            @Override
+            public Object handle(Channel channel, Object message) {
+                Request request = (Request) message;
+                DefaultResponse response = new DefaultResponse();
+                response.setRequestId(request.getRequestId());
+                response.setValue("error");
+                return response;
+            }
+        });
+        nettyServer.open();
+
+        Netty4Client nettyClient = new Netty4Client(url);
+        nettyClient.open();
+
+        DefaultRequest request = new DefaultRequest();
+        request.setRequestId(RequestIdGenerator.getRequestId());
+        request.setInterfaceName(url.getPath());
+        request.setMethodName("hello");
+        request.setParamtersDesc("void");
+
+        try {
+            nettyClient.request(request);
+            Assert.assertTrue(false);
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("response dataType not support"));
+        } finally {
+            nettyClient.close();
+            nettyServer.close();
+        }
+    }
+
+}
+
+class UnSerializableClass {
+
+    public String hello() {
+        return "I am a unserializable class";
+    }
+}

--- a/motan-transport-netty4/src/test/resources/log4j.properties
+++ b/motan-transport-netty4/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Output pattern : date [thread] priority category - message
+log4j.rootLogger=INFO,Console
+
+#Console
+log4j.appender.Console=org.apache.log4j.ConsoleAppender
+log4j.appender.Console.layout=org.apache.log4j.PatternLayout
+log4j.appender.Console.layout.ConversionPattern=%d [%t] %-5p [%c] - %m%n
+log4j.appender.Console.Threshold=INFO

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <module>motan-registry-consul</module>
         <module>motan-registry-zookeeper</module>
         <module>motan-benchmark</module>
+        <module>motan-transport-netty4</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
添加Netty4支持，之前的test case测试通过，在自己机器上跑了一下benchmark:
![2016-05-20 6 29 33](https://cloud.githubusercontent.com/assets/708349/15425117/ce8d7146-1eb8-11e6-9391-6138dfc3a96a.png)
结果如下:
### netty3

----------Benchmark Statistics--------------
Concurrents: 10
Runtime: 90 seconds
ClassName: com.weibo.motan.benchmark.TestStringRunnable
Params: 1
Benchmark Run Time: 60
Requests: 477,758, Success: 100%(477,758), Error: 0%(0)
Avg TPS: 7,962, Max TPS: 48,278, Min TPS: 47,522
Avg ResponseTime: 1.255ms
RT [0,1]: 85% 410,787/477,758
RT (1,5]: 12% 58,205/477,758
RT (5,10]: 1% 6,071/477,758
RT (10,50]: 0% 2,612/477,758
RT (50,100]: 0% 73/477,758
RT (100,500]: 0% 20/477,758
RT (500,1000]: 0% 0/477,758
RT >1000: 0% 0/477,758
### netty4

----------Benchmark Statistics--------------
Concurrents: 10
Runtime: 90 seconds
ClassName: com.weibo.motan.benchmark.TestStringRunnable
Params: 1
Benchmark Run Time: 60
Requests: 609,175, Success: 100%(609,175), Error: 0%(0)
Avg TPS: 10,152, Max TPS: 61,490, Min TPS: 60,341
Avg ResponseTime: 0.984ms
RT [0,1]: 89% 547,464/609,175
RT (1,5]: 8% 54,012/609,175
RT (5,10]: 0% 5,718/609,175
RT (10,50]: 0% 1,944/609,175
RT (50,100]: 0% 45/609,175
RT (100,500]: 0% 2/609,175
RT (500,1000]: 0% 0/609,175
RT >1000: 0% 0/609,175
