### PR TITLE
fix potential overflow of requestId

### DIFF
--- a/motan-core/src/main/java/com/weibo/api/motan/util/RequestIdGenerator.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/util/RequestIdGenerator.java
@@ -18,20 +18,26 @@ package com.weibo.api.motan.util;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+
 /**
  * 通过requestId能够知道大致请求的时间
  * 
  * <pre>
- * 		目前是 currentTimeMillis * 100000 + offset.incrementAndGet()
+ * 		目前是 currentTimeMillis * (2^20) + offset.incrementAndGet()
  * 
- * 		通过 requestId / (100000 * 1000) 能够得到秒
+ * 		通过 requestId / (2^20 * 1000) 能够得到秒
+ *
  * </pre>
  * 
  * @author maijunsheng
  * 
  */
 public class RequestIdGenerator {
-    private static AtomicLong offset = new AtomicLong(0);
+    protected static final AtomicLong offset = new AtomicLong(0);
+    protected static final AtomicLong lastOffsetResetTime = new AtomicLong();
+    protected static int BITS = 20;
+    protected static long MAX_COUNT_PER_MILLIS = 1L << BITS;
+
 
     /**
      * 获取 requestId
@@ -39,7 +45,21 @@ public class RequestIdGenerator {
      * @return
      */
     public static long getRequestId() {
-        return System.currentTimeMillis() * 100000 + offset.incrementAndGet();
+        long currentTime = System.currentTimeMillis();
+        long count = offset.incrementAndGet();
+        if(count == MAX_COUNT_PER_MILLIS){
+            synchronized (RequestIdGenerator.class){
+                if(offset.get() == MAX_COUNT_PER_MILLIS){
+                    offset.set(0);
+                    while(lastOffsetResetTime.get() == currentTime){
+                        currentTime = System.currentTimeMillis();
+                    }
+                    lastOffsetResetTime.set(currentTime);
+                }
+            }
+            count = offset.incrementAndGet();
+        }
+        return (currentTime << BITS) + count;
     }
 
     public static long getRequestIdFromClient() {

--- a/motan-core/src/main/java/com/weibo/api/motan/util/RequestIdGenerator.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/util/RequestIdGenerator.java
@@ -34,9 +34,8 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class RequestIdGenerator {
     protected static final AtomicLong offset = new AtomicLong(0);
-    protected static final AtomicLong lastOffsetResetTime = new AtomicLong();
-    protected static int BITS = 20;
-    protected static long MAX_COUNT_PER_MILLIS = 1L << BITS;
+    protected static final int BITS = 20;
+    protected static final long MAX_COUNT_PER_MILLIS = 1 << BITS;
 
 
     /**
@@ -47,14 +46,10 @@ public class RequestIdGenerator {
     public static long getRequestId() {
         long currentTime = System.currentTimeMillis();
         long count = offset.incrementAndGet();
-        if(count == MAX_COUNT_PER_MILLIS){
+        while(count >= MAX_COUNT_PER_MILLIS){
             synchronized (RequestIdGenerator.class){
-                if(offset.get() == MAX_COUNT_PER_MILLIS){
+                if(offset.get() >= MAX_COUNT_PER_MILLIS){
                     offset.set(0);
-                    while(lastOffsetResetTime.get() == currentTime){
-                        currentTime = System.currentTimeMillis();
-                    }
-                    lastOffsetResetTime.set(currentTime);
                 }
             }
             count = offset.incrementAndGet();

--- a/motan-core/src/test/java/com/weibo/api/motan/util/RequestIdGeneratorTest.java
+++ b/motan-core/src/test/java/com/weibo/api/motan/util/RequestIdGeneratorTest.java
@@ -5,7 +5,6 @@ package com.weibo.api.motan.util;
 
 import com.google.common.collect.Lists;
 import junit.framework.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
@@ -32,13 +31,8 @@ public class RequestIdGeneratorTest {
 
     @Test
     public void testNoMillisCollide() {
-        int oldBits = RequestIdGenerator.BITS;
-        long oldMaxCount = RequestIdGenerator.MAX_COUNT_PER_MILLIS;
 
-        RequestIdGenerator.BITS = 0;
-        RequestIdGenerator.MAX_COUNT_PER_MILLIS = 1;
-
-        int threadNum = Runtime.getRuntime().availableProcessors() * 2;
+        int threadNum = Runtime.getRuntime().availableProcessors() * 200;
         final CyclicBarrier cyclicBarrier = new CyclicBarrier(threadNum, new Runnable() {
             @Override
             public void run() {
@@ -54,7 +48,7 @@ public class RequestIdGeneratorTest {
                 @Override
                 public Boolean call() throws Exception {
                     cyclicBarrier.await();
-                    long id = RequestIdGenerator.getRequestId() >> RequestIdGenerator.BITS;
+                    long id = RequestIdGenerator.getRequestId();
                     boolean result = memory.putIfAbsent(id, "") == null;
                     return result;
 
@@ -78,9 +72,6 @@ public class RequestIdGeneratorTest {
                 throw new RuntimeException(e);
             }
         }
-
-        RequestIdGenerator.BITS = oldBits;
-        RequestIdGenerator.MAX_COUNT_PER_MILLIS = oldMaxCount;
 
     }
 

--- a/motan-core/src/test/java/com/weibo/api/motan/util/RequestIdGeneratorTest.java
+++ b/motan-core/src/test/java/com/weibo/api/motan/util/RequestIdGeneratorTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016, Blackboard Inc. All Rights Reserved.
+ */
+package com.weibo.api.motan.util;
+
+import com.google.common.collect.Lists;
+import junit.framework.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.*;
+
+/**
+ * ClassName: RequestIdGeneratorTest Function: TODO
+ *
+ * @Author: dtang
+ * @Date: 6/20/16, 9:07 PM
+ */
+public class RequestIdGeneratorTest {
+    @Test
+    public void testId() {
+        RequestIdGenerator.offset.set(0);
+
+        for (long i = 1L; i < RequestIdGenerator.MAX_COUNT_PER_MILLIS; i++) {
+            long id = RequestIdGenerator.getRequestId();
+            Assert.assertEquals(i, id & (RequestIdGenerator.MAX_COUNT_PER_MILLIS - 1));
+        }
+        Assert.assertEquals(1L, RequestIdGenerator.getRequestId() & (RequestIdGenerator.MAX_COUNT_PER_MILLIS - 1));
+        Assert.assertEquals(2L, RequestIdGenerator.getRequestId() & (RequestIdGenerator.MAX_COUNT_PER_MILLIS - 1));
+    }
+
+    @Test
+    public void testNoMillisCollide() {
+        int oldBits = RequestIdGenerator.BITS;
+        long oldMaxCount = RequestIdGenerator.MAX_COUNT_PER_MILLIS;
+
+        RequestIdGenerator.BITS = 0;
+        RequestIdGenerator.MAX_COUNT_PER_MILLIS = 1;
+
+        int threadNum = Runtime.getRuntime().availableProcessors() * 2;
+        final CyclicBarrier cyclicBarrier = new CyclicBarrier(threadNum, new Runnable() {
+            @Override
+            public void run() {
+                System.out.println("barrier start");
+            }
+        });
+        final ConcurrentMap<Long, Object> memory = new ConcurrentHashMap<Long, Object>();
+        ExecutorService executor = Executors.newFixedThreadPool(threadNum);
+        List<Future<Boolean>> futureList = Lists.newArrayList();
+
+        for (int i = 0; i < threadNum; i++) {
+            futureList.add(executor.submit(new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws Exception {
+                    cyclicBarrier.await();
+                    long id = RequestIdGenerator.getRequestId() >> RequestIdGenerator.BITS;
+                    boolean result = memory.putIfAbsent(id, "") == null;
+                    return result;
+
+                }
+            }));
+        }
+        Assert.assertEquals(threadNum, futureList.size());
+        try {
+            executor.shutdown();
+            executor.awaitTermination(100, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        Assert.assertEquals(threadNum, memory.size());
+        for(Future<Boolean> future: futureList){
+            try {
+                Assert.assertTrue(future.get());
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            } catch (ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        RequestIdGenerator.BITS = oldBits;
+        RequestIdGenerator.MAX_COUNT_PER_MILLIS = oldMaxCount;
+
+    }
+
+}


### PR DESCRIPTION
issue description is [here](https://github.com/weibocom/motan/issues/89).

a long value representing requestId composes of two parts: 
1. higher bits from 63 to 20 is system time millis 
2. lower bits from 19 to 0 is offset count

if offset count equals to 2^20, it will be reset to 0 and the last offset reset time is recorded. If during one millis second, offset count hit max again, it will wait until this millis second passes. 
