### PR TITLE
Update hprose-java version

### DIFF
--- a/motan-extension/serialization-extension/pom.xml
+++ b/motan-extension/serialization-extension/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.hprose</groupId>
             <artifactId>hprose-java</artifactId>
-            <version>2.0.16</version>
+            <version>[2.0.18,)</version>
         </dependency>
         <dependency>
             <groupId>com.weibo</groupId>


### PR DESCRIPTION
2.0.18 版本修正了一个日期类型引用反序列化的 bug。所以把版本改为最低 2.0.18 了。
