### PR TITLE
available after register while heartbeat switcher is open

### DIFF
--- a/motan-core/src/main/java/com/weibo/api/motan/registry/support/AbstractRegistry.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/registry/support/AbstractRegistry.java
@@ -77,6 +77,10 @@ public abstract class AbstractRegistry implements Registry {
         LoggerUtil.info("[{}] Url ({}) will register to Registry [{}]", registryClassName, url, registryUrl.getIdentity());
         doRegister(removeUnnecessaryParmas(url.createCopy()));
         registeredServiceUrls.add(url);
+        // available if heartbeat switcher already open
+        if (MotanSwitcherUtil.isOpen(MotanConstants.REGISTRY_HEARTBEAT_SWITCHER)) {
+            available(url);
+        }
     }
 
     @Override


### PR DESCRIPTION
fix:如果在心跳开关listener注册前打开心跳开关，服务状态一直为unvailable状态。
实现：register后，如果心跳开关已经是打开状态，同步执行available方法