### PR TITLE
support opentracing & demo

### DIFF
--- a/motan-extension/filter-extension/filter-opentracing/pom.xml
+++ b/motan-extension/filter-extension/filter-opentracing/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<!-- ~ Copyright 2009-2016 Weibo, Inc. ~ ~ Licensed under the Apache License, 
+    Version 2.0 (the "License"); ~ you may not use this file except in compliance 
+    with the License. ~ You may obtain a copy of the License at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 
+    ~ ~ Unless required by applicable law or agreed to in writing, software ~ 
+    distributed under the License is distributed on an "AS IS" BASIS, ~ WITHOUT 
+    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. ~ See the 
+    License for the specific language governing permissions and ~ limitations 
+    under the License. -->
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.weibo</groupId>
+        <artifactId>filter-extension</artifactId>
+        <version>0.2.3-SNAPSHOT</version>
+    </parent>
+    <artifactId>filter-opentracing</artifactId>
+    <name>filter-opentracing</name>
+    <url>https://github.com/weibocom/motan</url>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.weibo</groupId>
+            <artifactId>motan-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-api</artifactId>
+            <version>0.20.2</version>
+        </dependency>
+
+        <!-- for test -->
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-mock</artifactId>
+            <version>0.20.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing.brave</groupId>
+            <artifactId>brave-opentracing</artifactId>
+            <version>0.16.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave-spancollector-http</artifactId>
+            <version>3.16.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.weibo</groupId>
+            <artifactId>motan-transport-netty</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.weibo</groupId>
+            <artifactId>motan-springsupport</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>4.2.4.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/motan-extension/filter-extension/filter-opentracing/pom.xml
+++ b/motan-extension/filter-extension/filter-opentracing/pom.xml
@@ -21,6 +21,7 @@
     <url>https://github.com/weibocom/motan</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <opentracing.version>0.20.2</opentracing.version>
     </properties>
     <dependencies>
         <dependency>
@@ -31,14 +32,19 @@
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
-            <version>0.20.2</version>
+            <version>${opentracing.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentracing</groupId>
+            <artifactId>opentracing-impl</artifactId>
+            <version>${opentracing.version}</version>
         </dependency>
 
         <!-- for test -->
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-mock</artifactId>
-            <version>0.20.2</version>
+            <version>${opentracing.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/motan-extension/filter-extension/filter-opentracing/pom.xml
+++ b/motan-extension/filter-extension/filter-opentracing/pom.xml
@@ -21,7 +21,7 @@
     <url>https://github.com/weibocom/motan</url>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <opentracing.version>0.20.2</opentracing.version>
+        <opentracing.version>0.20.4</opentracing.version>
     </properties>
     <dependencies>
         <dependency>

--- a/motan-extension/filter-extension/filter-opentracing/src/main/java/com/weibo/api/motan/filter/opentracing/OpenTracingContext.java
+++ b/motan-extension/filter-extension/filter-opentracing/src/main/java/com/weibo/api/motan/filter/opentracing/OpenTracingContext.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2009-2016 Weibo, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.weibo.api.motan.filter.opentracing;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+
+import com.weibo.api.motan.rpc.RpcContext;
+
+/**
+ * 
+ * @Description OpenTracingContext hold a TracerFactory which can replaced by different tracer
+ *              implementation.
+ * @author zhanglei
+ * @date Dec 8, 2016
+ *
+ */
+public class OpenTracingContext {
+    // replace TracerFactory with any tracer implementation
+    public static TracerFactory tracerFactory = TracerFactory.DEFAULT;
+    public static final String ACTIVE_SPAN = "ot_active_span";
+
+    public static Tracer getTracer() {
+        return tracerFactory.getTracer();
+    }
+
+    public static Span getActiveSpan() {
+        Object span = RpcContext.getContext().getAttribute(ACTIVE_SPAN);
+        if (span != null && span instanceof Span) {
+            return (Span) span;
+        }
+        return null;
+    }
+
+    public static void setActiveSpan(Span span) {
+        RpcContext.getContext().putAttribute(ACTIVE_SPAN, span);
+    }
+
+    public void setTracerFactory(TracerFactory tracerFactory) {
+        OpenTracingContext.tracerFactory = tracerFactory;
+    }
+}

--- a/motan-extension/filter-extension/filter-opentracing/src/main/java/com/weibo/api/motan/filter/opentracing/OpenTracingFilter.java
+++ b/motan-extension/filter-extension/filter-opentracing/src/main/java/com/weibo/api/motan/filter/opentracing/OpenTracingFilter.java
@@ -13,6 +13,7 @@
  */
 package com.weibo.api.motan.filter.opentracing;
 
+import io.opentracing.NoopTracer;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -49,8 +50,8 @@ public class OpenTracingFilter implements Filter {
 
     @Override
     public Response filter(Caller<?> caller, Request request) {
-        Tracer tracer = OpenTracingContext.getTracer();
-        if (tracer == null) {
+        Tracer tracer = getTracer();
+        if (tracer == null || tracer instanceof NoopTracer) {
             return caller.call(request);
         }
         if (caller instanceof Provider) { // server end
@@ -58,6 +59,10 @@ public class OpenTracingFilter implements Filter {
         } else { // client end
             return processRefererTrace(tracer, caller, request);
         }
+    }
+    
+    protected Tracer getTracer(){
+        return OpenTracingContext.getTracer();
     }
 
     /**

--- a/motan-extension/filter-extension/filter-opentracing/src/main/java/com/weibo/api/motan/filter/opentracing/OpenTracingFilter.java
+++ b/motan-extension/filter-extension/filter-opentracing/src/main/java/com/weibo/api/motan/filter/opentracing/OpenTracingFilter.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2009-2016 Weibo, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.weibo.api.motan.filter.opentracing;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.Tracer.SpanBuilder;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMap;
+import io.opentracing.propagation.TextMapExtractAdapter;
+
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+import com.weibo.api.motan.core.extension.Activation;
+import com.weibo.api.motan.core.extension.SpiMeta;
+import com.weibo.api.motan.filter.Filter;
+import com.weibo.api.motan.rpc.Caller;
+import com.weibo.api.motan.rpc.Provider;
+import com.weibo.api.motan.rpc.Request;
+import com.weibo.api.motan.rpc.Response;
+import com.weibo.api.motan.util.LoggerUtil;
+import com.weibo.api.motan.util.MotanFrameworkUtil;
+
+/**
+ * 
+ * @Description This filter enables distributed tracing in Motan clients and servers via @see <a
+ *              href="http://opentracing.io">The OpenTracing Project </a> : a set of consistent,
+ *              expressive, vendor-neutral APIs for distributed tracing and context propagation.
+ * @author zhanglei
+ * @date Dec 8, 2016
+ *
+ */
+@SpiMeta(name = "opentracing")
+@Activation(sequence = 30)
+public class OpenTracingFilter implements Filter {
+
+    @Override
+    public Response filter(Caller<?> caller, Request request) {
+        Tracer tracer = OpenTracingContext.getTracer();
+        if (tracer == null) {
+            return caller.call(request);
+        }
+        if (caller instanceof Provider) { // server end
+            return processProviderTrace(tracer, caller, request);
+        } else { // client end
+            return processRefererTrace(tracer, caller, request);
+        }
+    }
+
+    /**
+     * process trace in client end
+     * 
+     * @param caller
+     * @param request
+     * @return
+     */
+    protected Response processRefererTrace(Tracer tracer, Caller<?> caller, Request request) {
+        String operationName = buildOperationName(request);
+        SpanBuilder spanBuilder = tracer.buildSpan(operationName);
+        Span activeSpan = OpenTracingContext.getActiveSpan();
+        if (activeSpan != null) {
+            spanBuilder.asChildOf(activeSpan);
+        }
+        Span span = spanBuilder.start();
+        span.setTag("requestId", request.getRequestId());
+
+        attachTraceInfo(tracer, span, request);
+        return process(caller, request, span);
+
+    }
+
+    protected Response process(Caller<?> caller, Request request, Span span) {
+        Exception ex = null;
+        boolean exception = true;
+        try {
+            Response response = caller.call(request);
+            if (response.getException() != null) {
+                ex = response.getException();
+            } else {
+                exception = false;
+            }
+            return response;
+        } catch (RuntimeException e) {
+            ex = e;
+            throw e;
+        } finally {
+            try {
+                if (exception) {
+                    span.log("request fail." + (ex == null ? "unknown exception" : ex.getMessage()));
+                } else {
+                    span.log("request success.");
+                }
+                span.finish();
+            } catch (Exception e) {
+                LoggerUtil.error("opentracing span finish error!", e);
+            }
+        }
+    }
+
+    protected String buildOperationName(Request request) {
+        return "Motan_" + MotanFrameworkUtil.getGroupMethodString(request);
+    }
+
+    protected void attachTraceInfo(Tracer tracer, Span span, final Request request) {
+        tracer.inject(span.context(), Format.Builtin.TEXT_MAP, new TextMap() {
+
+            @Override
+            public void put(String key, String value) {
+                request.setAttachment(key, value);
+            }
+
+            @Override
+            public Iterator<Entry<String, String>> iterator() {
+                throw new UnsupportedOperationException("TextMapInjectAdapter should only be used with Tracer.inject()");
+            }
+        });
+    }
+
+    /**
+     * process trace in server end
+     * 
+     * @param caller
+     * @param request
+     * @return
+     */
+    protected Response processProviderTrace(Tracer tracer, Caller<?> caller, Request request) {
+        Span span = extractTraceInfo(request, tracer);
+        span.setTag("requestId", request.getRequestId());
+        OpenTracingContext.setActiveSpan(span);
+        return process(caller, request, span);
+    }
+
+    protected Span extractTraceInfo(Request request, Tracer tracer) {
+        String operationName = buildOperationName(request);
+        SpanBuilder span = tracer.buildSpan(operationName);
+        try {
+            SpanContext spanContext = tracer.extract(Format.Builtin.TEXT_MAP, new TextMapExtractAdapter(request.getAttachments()));
+            if (spanContext != null) {
+                span.asChildOf(spanContext);
+            }
+        } catch (Exception e) {
+            span.withTag("Error", "extract from request fail, error msg:" + e.getMessage());
+        }
+        return span.start();
+    }
+
+}

--- a/motan-extension/filter-extension/filter-opentracing/src/main/java/com/weibo/api/motan/filter/opentracing/TracerFactory.java
+++ b/motan-extension/filter-extension/filter-opentracing/src/main/java/com/weibo/api/motan/filter/opentracing/TracerFactory.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.filter.opentracing;
+
+import io.opentracing.Tracer;
+/**
+ * 
+ * @Description TracerFactory
+ * @author zhanglei
+ * @date Dec 8, 2016
+ *
+ */
+public interface TracerFactory {
+    public static final TracerFactory DEFAULT = new DefaultTracerFactory();
+    
+    /**
+     * get a Tracer implementation.
+     * this method may called every request, consider whether singleton pattern is needed 
+     * @return
+     */
+    Tracer getTracer();
+
+    class DefaultTracerFactory implements TracerFactory{
+        @Override
+        public Tracer getTracer() {
+            return null;
+        }
+        
+    }
+}

--- a/motan-extension/filter-extension/filter-opentracing/src/main/resources/META-INF/services/com.weibo.api.motan.filter.Filter
+++ b/motan-extension/filter-extension/filter-opentracing/src/main/resources/META-INF/services/com.weibo.api.motan.filter.Filter
@@ -1,0 +1,17 @@
+#
+#  Copyright 2009-2016 Weibo, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+com.weibo.api.motan.filter.opentracing.OpenTracingFilter

--- a/motan-extension/filter-extension/filter-opentracing/src/test/java/com/weibo/api/motan/filter/opentracing/HelloService.java
+++ b/motan-extension/filter-extension/filter-opentracing/src/test/java/com/weibo/api/motan/filter/opentracing/HelloService.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.filter.opentracing;
+
+public interface HelloService {
+    String sayHello(String name);
+}

--- a/motan-extension/filter-extension/filter-opentracing/src/test/java/com/weibo/api/motan/filter/opentracing/HelloServiceImpl.java
+++ b/motan-extension/filter-extension/filter-opentracing/src/test/java/com/weibo/api/motan/filter/opentracing/HelloServiceImpl.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.filter.opentracing;
+
+public class HelloServiceImpl implements HelloService {
+
+    @Override
+    public String sayHello(String name) {
+        return "hello," + name;
+    }
+
+}

--- a/motan-extension/filter-extension/filter-opentracing/src/test/java/com/weibo/api/motan/filter/opentracing/OpenTracingFilterTest.java
+++ b/motan-extension/filter-extension/filter-opentracing/src/test/java/com/weibo/api/motan/filter/opentracing/OpenTracingFilterTest.java
@@ -16,7 +16,7 @@ package com.weibo.api.motan.filter.opentracing;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import io.opentracing.Tracer;
-import io.opentracing.impl.BraveTracer;
+//import io.opentracing.impl.BraveTracer;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
 
@@ -110,10 +110,11 @@ public class OpenTracingFilterTest {
         assertEquals(response, res);
         checkMockTracer();
 
-        tracer = new BraveTracer();// use bravetracer
-        res = OTFilter.filter(refer, request);
-        assertEquals(response, res);
-        checkBraveTrace();
+        // brave test must run with jdk1.8 
+//        tracer = new BraveTracer();// use bravetracer
+//        res = OTFilter.filter(refer, request);
+//        assertEquals(response, res);
+//        checkBraveTrace();
     }
 
     @Test
@@ -148,12 +149,12 @@ public class OpenTracingFilterTest {
         }
     }
 
-    private void checkBraveTrace() {
-        if (tracer instanceof BraveTracer) {
-            assertTrue(request.getAttachments().containsKey("X-B3-TraceId"));
-            assertTrue(request.getAttachments().containsKey("X-B3-SpanId"));
-            assertTrue(request.getAttachments().containsKey("X-B3-Sampled"));
-        }
-    }
+//    private void checkBraveTrace() {
+//        if (tracer instanceof BraveTracer) {
+//            assertTrue(request.getAttachments().containsKey("X-B3-TraceId"));
+//            assertTrue(request.getAttachments().containsKey("X-B3-SpanId"));
+//            assertTrue(request.getAttachments().containsKey("X-B3-Sampled"));
+//        }
+//    }
 
 }

--- a/motan-extension/filter-extension/filter-opentracing/src/test/java/com/weibo/api/motan/filter/opentracing/OpenTracingFilterTest.java
+++ b/motan-extension/filter-extension/filter-opentracing/src/test/java/com/weibo/api/motan/filter/opentracing/OpenTracingFilterTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2009-2016 Weibo, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.weibo.api.motan.filter.opentracing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import io.opentracing.Tracer;
+import io.opentracing.impl.BraveTracer;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.weibo.api.motan.common.URLParamType;
+import com.weibo.api.motan.filter.Filter;
+import com.weibo.api.motan.rpc.AbstractReferer;
+import com.weibo.api.motan.rpc.DefaultProvider;
+import com.weibo.api.motan.rpc.DefaultRequest;
+import com.weibo.api.motan.rpc.DefaultResponse;
+import com.weibo.api.motan.rpc.Provider;
+import com.weibo.api.motan.rpc.Referer;
+import com.weibo.api.motan.rpc.Request;
+import com.weibo.api.motan.rpc.Response;
+import com.weibo.api.motan.rpc.URL;
+
+/**
+ * 
+ * @Description UT
+ * @author zhanglei
+ * @date Dec 9, 2016
+ *
+ */
+public class OpenTracingFilterTest {
+    Filter OTFilter;
+    Tracer tracer;
+    Referer<HelloService> refer;
+    Provider<HelloService> provider;
+    DefaultRequest request;
+    DefaultResponse response;
+
+
+    @Before
+    public void setUp() throws Exception {
+        OTFilter = new OpenTracingFilter();
+        tracer = new MockTracer();
+        OpenTracingContext.tracerFactory = new TracerFactory() {
+            @Override
+            public Tracer getTracer() {
+                return tracer;
+            }
+        };
+        URL url = new URL("motan", "localhost", 8002, "HelloService");
+        request = new DefaultRequest();
+        request.setInterfaceName("HelloService");
+        request.setAttachment(URLParamType.group.name(), "test");
+        request.setMethodName("sayHello");
+        request.setParamtersDesc("java.lang.String");
+        response = new DefaultResponse();
+        refer = new AbstractReferer<HelloService>(HelloService.class, url) {
+            @Override
+            public void destroy() {}
+
+            @Override
+            public boolean isAvailable() {
+                return true;
+            }
+
+            @Override
+            protected Response doCall(Request request) {
+                return response;
+            }
+
+            @Override
+            protected boolean doInit() {
+                return true;
+            }
+        };
+
+        provider = new DefaultProvider<HelloService>(new HelloServiceImpl(), url, HelloService.class) {
+
+            @Override
+            public Response call(Request request) {
+                return response;
+            }
+
+        };
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        OpenTracingContext.tracerFactory = TracerFactory.DEFAULT;
+    }
+
+    @Test
+    public void testRefererFilter() {
+        Response res = OTFilter.filter(refer, request);
+        assertEquals(response, res);
+        checkMockTracer();
+
+        tracer = new BraveTracer();// use bravetracer
+        res = OTFilter.filter(refer, request);
+        assertEquals(response, res);
+        checkBraveTrace();
+    }
+
+    @Test
+    public void testProviderFilter() {
+        Response res = OTFilter.filter(provider, request);
+        assertEquals(response, res);
+        checkMockTracer();
+    }
+
+    @Test
+    public void testException() {
+        response.setException(new RuntimeException("in test"));
+        Response res = OTFilter.filter(refer, request);
+        assertEquals(response, res);
+        if (tracer instanceof MockTracer) {
+            MockSpan span = ((MockTracer) tracer).finishedSpans().get(0);
+            assertEquals(span.logEntries().size(), 1);
+            assertTrue("request fail.in test".equals(span.logEntries().get(0).fields().get("event")));
+        }
+    }
+
+    private void checkMockTracer() {
+        if (tracer instanceof MockTracer) {
+            MockTracer mt = (MockTracer) tracer;
+            assertEquals(1, mt.finishedSpans().size());
+            MockSpan span = mt.finishedSpans().get(0);
+            assertEquals(span.operationName(), "Motan_test_HelloService.sayHello(java.lang.String)");
+            assertEquals(span.parentId(), 0);
+            assertEquals(span.logEntries().size(), 1);
+            assertTrue("request success.".equals(span.logEntries().get(0).fields().get("event")));
+            assertTrue(span.tags().containsKey("requestId"));
+        }
+    }
+
+    private void checkBraveTrace() {
+        if (tracer instanceof BraveTracer) {
+            assertTrue(request.getAttachments().containsKey("X-B3-TraceId"));
+            assertTrue(request.getAttachments().containsKey("X-B3-SpanId"));
+            assertTrue(request.getAttachments().containsKey("X-B3-Sampled"));
+        }
+    }
+
+}

--- a/motan-extension/filter-extension/filter-opentracing/src/test/java/com/weibo/api/motan/filter/opentracing/zipkin/demo/HelloClient.java
+++ b/motan-extension/filter-extension/filter-opentracing/src/test/java/com/weibo/api/motan/filter/opentracing/zipkin/demo/HelloClient.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.filter.opentracing.zipkin.demo;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import com.weibo.api.motan.filter.opentracing.HelloService;
+import com.weibo.api.motan.filter.opentracing.OpenTracingContext;
+
+public class HelloClient {
+    public static void main(String[] args) {
+        ApplicationContext ctx = new ClassPathXmlApplicationContext("classpath:motan_client.xml");
+        
+        // set tracer implementation
+        OpenTracingContext.tracerFactory = new MyTracerFactory();
+        
+        // use motan
+        HelloService service = (HelloService) ctx.getBean("helloService");
+        for(int i = 0; i< 10; i++){
+            try{
+                System.out.println(service.sayHello("motan"));
+            }catch(Exception e){
+                e.printStackTrace();
+            }
+        }
+        System.exit(0);
+    }
+}

--- a/motan-extension/filter-extension/filter-opentracing/src/test/java/com/weibo/api/motan/filter/opentracing/zipkin/demo/HelloServer.java
+++ b/motan-extension/filter-extension/filter-opentracing/src/test/java/com/weibo/api/motan/filter/opentracing/zipkin/demo/HelloServer.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.filter.opentracing.zipkin.demo;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class HelloServer {
+    public static void main(String[] args) {
+        //set tracer implementation by spring config. see motan_server.xml
+        
+        ApplicationContext applicationContext = new ClassPathXmlApplicationContext("classpath:motan_server.xml");
+        System.out.println("server start...");
+    }
+
+}

--- a/motan-extension/filter-extension/filter-opentracing/src/test/java/com/weibo/api/motan/filter/opentracing/zipkin/demo/MyTracerFactory.java
+++ b/motan-extension/filter-extension/filter-opentracing/src/test/java/com/weibo/api/motan/filter/opentracing/zipkin/demo/MyTracerFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2009-2016 Weibo, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.weibo.api.motan.filter.opentracing.zipkin.demo;
+
+import io.opentracing.Tracer;
+import io.opentracing.impl.BraveTracer;
+import io.opentracing.mock.MockTracer;
+
+import com.weibo.api.motan.filter.opentracing.TracerFactory;
+
+public class MyTracerFactory implements TracerFactory {
+    // any tracer implementation
+    final Tracer mockTracer = new MockTracer();
+    final Tracer braveTracer = new BraveTracer();
+
+    @Override
+    public Tracer getTracer() {
+//        return mockTracer;
+        return braveTracer;
+    }
+
+}

--- a/motan-extension/filter-extension/filter-opentracing/src/test/resources/motan_client.xml
+++ b/motan-extension/filter-extension/filter-opentracing/src/test/resources/motan_client.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  Copyright 2009-2016 Weibo, Inc.
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:motan="http://api.weibo.com/schema/motan"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+       http://api.weibo.com/schema/motan http://api.weibo.com/schema/motan.xsd">
+
+    <motan:referer id="helloService" directUrl="127.0.0.1:8002" filter="opentracing"
+                   interface="com.weibo.api.motan.filter.opentracing.HelloService"/>
+</beans>

--- a/motan-extension/filter-extension/filter-opentracing/src/test/resources/motan_server.xml
+++ b/motan-extension/filter-extension/filter-opentracing/src/test/resources/motan_server.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  Copyright 2009-2016 Weibo, Inc.
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:motan="http://api.weibo.com/schema/motan"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+       http://api.weibo.com/schema/motan http://api.weibo.com/schema/motan.xsd">
+
+    <bean id="serviceImpl" class="com.weibo.api.motan.filter.opentracing.HelloServiceImpl"/>
+
+    <motan:service interface="com.weibo.api.motan.filter.opentracing.HelloService" ref="serviceImpl" filter="opentracing" export="8002" />
+    
+    <!-- replace tracer implementation -->
+    <bean id="myOpenTracingFactory" class="com.weibo.api.motan.filter.opentracing.zipkin.demo.MyTracerFactory"></bean>
+    <bean id="opentracingContext" class="com.weibo.api.motan.filter.opentracing.OpenTracingContext">
+        <property name="tracerFactory" ref="myOpenTracingFactory"/>
+    </bean>
+</beans>

--- a/motan-extension/filter-extension/pom.xml
+++ b/motan-extension/filter-extension/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!-- ~ Copyright 2009-2016 Weibo, Inc. ~ ~ Licensed under the Apache License, 
     Version 2.0 (the "License"); ~ you may not use this file except in compliance 
     with the License. ~ You may obtain a copy of the License at ~ ~ http://www.apache.org/licenses/LICENSE-2.0 
@@ -7,31 +7,20 @@
     WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. ~ See the 
     License for the specific language governing permissions and ~ limitations 
     under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.weibo</groupId>
-        <artifactId>motan</artifactId>
+        <artifactId>motan-extension</artifactId>
         <version>0.2.3-SNAPSHOT</version>
     </parent>
-    <artifactId>motan-extension</artifactId>
-    <name>motan-extension</name>
+    <artifactId>filter-extension</artifactId>
+    <name>filter-extension</name>
     <url>https://github.com/weibocom/motan</url>
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
     <packaging>pom</packaging>
-    <dependencies>
-        <dependency>
-            <groupId>com.weibo</groupId>
-            <artifactId>motan-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-    </dependencies>
     <modules>
-        <module>serialization-extension</module>
-        <module>protocol-extension</module>
-        <module>filter-extension</module>
+        <module>filter-opentracing</module>
     </modules>
 </project>


### PR DESCRIPTION
support opentracing

实现方式：motan filter SPI。OpenTracingFilter中按OT 的api对server端和client端进行trace处理。
可用通过spirng 配置方式或api方式替换OpenTracingContext中的TracerFactory， 来实现不同tracer的替换。
demo在test classpath下的com.weibo.api.motan.filter.opentracing.zipkin.demo包下，其中server端使用spring配置方式替换具体trace实现，client端通过代码api替换。