### PR TITLE
接口不使用@Spi注解，但是如果实现类有@Activation注解的话会报NullPointerException

### DIFF
--- a/motan-core/src/main/java/com/weibo/api/motan/core/extension/ExtensionLoader.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/core/extension/ExtensionLoader.java
@@ -95,6 +95,8 @@ public class ExtensionLoader<T> {
         try {
             Spi spi = type.getAnnotation(Spi.class);
 
+            if(spi==null) return null;
+
             if (spi.scope() == Scope.SINGLETON) {
                 return getSingletonInstance(name);
             } else {


### PR DESCRIPTION
接口A如果不用@Spi注解，但是在META-INF/services目录下配置的实现类B使用了@Activation注解。

`
96            Spi spi = type.getAnnotation(Spi.class);
`

这时候spi是null，现在直接调spi.scope()方法直接抛NullpointerException了，可以做一下防护。