### PR TITLE
add restful protocol support by integrate jboss resteasy and testcase

### DIFF
--- a/motan-core/src/main/java/com/weibo/api/motan/protocol/support/ProtocolFilterDecorator.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/protocol/support/ProtocolFilterDecorator.java
@@ -41,7 +41,7 @@ import com.weibo.api.motan.rpc.Response;
 import com.weibo.api.motan.rpc.URL;
 
 /**
- * 
+ *
  * Decorate the protocol, to add more features.
  *
  * @author fishermen
@@ -135,7 +135,7 @@ public class ProtocolFilterDecorator implements Protocol {
         return lastRef;
     }
 
-    private <T> Provider<T> decorateWithFilter(Provider<T> provider, URL url) {
+    private <T> Provider<T> decorateWithFilter(final Provider<T> provider, URL url) {
         List<Filter> filters = getFilters(url, MotanConstants.NODE_TYPE_SERVICE);
         if (filters == null || filters.size() == 0) {
             return provider;
@@ -179,6 +179,11 @@ public class ProtocolFilterDecorator implements Protocol {
                 public boolean isAvailable() {
                     return lp.isAvailable();
                 }
+
+				@Override
+				public T getImpl() {
+					return provider.getImpl();
+				}
             };
         }
         return lastProvider;
@@ -191,7 +196,7 @@ public class ProtocolFilterDecorator implements Protocol {
 	 * 2）根据filter配置获取新的filters，并和默认的filter列表合并；
 	 * 3）再根据一些其他配置判断是否需要增加其他filter，如根据accessLog进行判断，是否需要增加accesslog
 	 * </pre>
-     * 
+     *
      * @param url
      * @param key
      * @return

--- a/motan-core/src/main/java/com/weibo/api/motan/rpc/DefaultProvider.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/rpc/DefaultProvider.java
@@ -27,7 +27,7 @@ import com.weibo.api.motan.util.LoggerUtil;
 /**
  * @author maijunsheng
  * @version 创建时间：2013-5-23
- * 
+ *
  */
 @SpiMeta(name = "motan")
 public class DefaultProvider<T> extends AbstractProvider<T> {
@@ -36,6 +36,11 @@ public class DefaultProvider<T> extends AbstractProvider<T> {
     public DefaultProvider(T proxyImpl, URL url, Class<T> clz) {
         super(url, clz);
         this.proxyImpl = proxyImpl;
+    }
+
+    @Override
+    public T getImpl(){
+    	return proxyImpl;
     }
 
     @Override

--- a/motan-core/src/main/java/com/weibo/api/motan/rpc/Provider.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/rpc/Provider.java
@@ -20,9 +20,9 @@ import com.weibo.api.motan.core.extension.Scope;
 import com.weibo.api.motan.core.extension.Spi;
 
 /**
- * 
+ *
  * Service provider.
- * 
+ *
  * @author fishermen
  * @version V1.0 created at: 2013-5-16
  */
@@ -30,4 +30,6 @@ import com.weibo.api.motan.core.extension.Spi;
 public interface Provider<T> extends Caller<T> {
 
     Class<T> getInterface();
+
+    T getImpl();
 }

--- a/motan-core/src/test/java/com/weibo/api/motan/protocol/rpc/DefaultRpcProtocolTest.java
+++ b/motan-core/src/test/java/com/weibo/api/motan/protocol/rpc/DefaultRpcProtocolTest.java
@@ -63,9 +63,9 @@ public class DefaultRpcProtocolTest {
         }
 
         defaultRpcProtocol.export(new Provider<IHello>() {
+        	private IHello hello = new Hello();
             @Override
             public Response call(Request request) {
-                IHello hello = new Hello();
                 hello.hello();
                 return new DefaultResponse("hello");
             }
@@ -97,6 +97,11 @@ public class DefaultRpcProtocolTest {
             public Class<IHello> getInterface() {
                 return IHello.class;
             }
+
+			@Override
+			public IHello getImpl() {
+				return hello;
+			}
 
         }, url);
 

--- a/motan-extension/protocol-extension/motan-protocol-restful/pom.xml
+++ b/motan-extension/protocol-extension/motan-protocol-restful/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0"?>
+<!--
+  ~  Copyright 2009-2016 Weibo, Inc.
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.weibo</groupId>
+    <artifactId>protocol-extension</artifactId>
+    <version>0.3.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>motan-protocol-restful</artifactId>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <resteasy.version>3.0.7.Final</resteasy.version>
+    <junit.version>4.12</junit.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+     <version>7.0.75</version>
+     <scope>test</scope>
+   </dependency>
+   <dependency>
+     <groupId>org.apache.tomcat.embed</groupId>
+     <artifactId>tomcat-embed-logging-juli</artifactId>
+     <version>7.0.75</version>
+     <scope>test</scope>
+   </dependency>
+
+    <dependency>
+      <groupId>com.weibo</groupId>
+      <artifactId>motan-core</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.0.1</version>
+   </dependency>
+   <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>provided</scope>
+   </dependency>
+
+   <dependency>
+     <groupId>org.jboss.resteasy</groupId>
+     <artifactId>resteasy-netty</artifactId>
+     <version>${resteasy.version}</version>
+   </dependency>
+
+   <dependency>
+     <groupId>org.jboss.resteasy</groupId>
+     <artifactId>resteasy-jaxrs</artifactId>
+     <version>${resteasy.version}</version>
+     <exclusions>
+       <exclusion>
+         <groupId>net.jcip</groupId>
+         <artifactId>jcip-annotations</artifactId>
+       </exclusion>
+       <exclusion>
+         <groupId>org.jboss.spec.javax.annotation</groupId>
+         <artifactId>jboss-annotations-api_1.1_spec</artifactId>
+       </exclusion>
+       <!-- multipart使用 -->
+       <exclusion>
+         <groupId>javax.activation</groupId>
+         <artifactId>activation</artifactId>
+       </exclusion>
+     </exclusions>
+   </dependency>
+   <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-client</artifactId>
+      <version>${resteasy.version}</version>
+   </dependency>
+   <dependency>
+     <groupId>org.jboss.resteasy</groupId>
+     <artifactId>resteasy-jackson2-provider</artifactId>
+     <version>${resteasy.version}</version>
+   </dependency>
+  </dependencies>
+</project>

--- a/motan-extension/protocol-extension/motan-protocol-restful/restful.md
+++ b/motan-extension/protocol-extension/motan-protocol-restful/restful.md
@@ -1,0 +1,99 @@
+集成jboss resteasy支持restful协议
+
+### 功能支持
+1. 支持rpc单独进程和部署到servlet容器中
+2. 完全支持原有服务治理功能
+3. 支持rpc request/response的attachment机制
+4. 完全支持rpc filter机制
+5. rest服务编程完全按照JAX-RS代码方式编写
+
+### 快速入门
+
+服务接口
+
+```java
+@Path("/rest")
+public interface HelloResource{
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  List<User> hello(@CookieParam("uid") int uid);
+
+  @GET
+  @Path("/primitive")
+  @Produces(MediaType.TEXT_PLAIN)
+  String testPrimitiveType();
+
+  @POST
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+  @Produces(MediaType.APPLICATION_JSON)
+  Response add(@FormParam("id") int id, @FormParam("name") String name);
+
+  @GET
+  @Path("/exception")
+  @Produces(MediaType.APPLICATION_JSON)
+  void testException();
+```
+
+服务实现
+
+```java
+public class RestHelloResource implements HelloResource{
+
+  public List<User> hello(int id){
+    return Arrays.asList(new User(id, "de"));
+  }
+
+  @Override
+  public String testPrimitiveType(){
+    return "helloworld";
+  }
+
+  @Override
+  public Response add(int id, String name){
+    return Response.ok().cookie(new NewCookie("ck", String.valueOf(id))).entity(new User(id, name)).build();
+  }
+
+  @Override
+  public void testException(){
+    throw new UnsupportedOperationException("unsupport");
+  }
+
+}
+```
+
+### 配置restserver
+
+#### 独立rpc进程方式
+
+`<motan:protocol name="restful" endpointFactory="netty" />`
+
+#### 集成到java应用服务器中(如部署到tomcat中)
+
+此时需要注意contextpath问题
+
+`<motan:protocol name="restful" endpointFactory="servlet" />` 服务端还需配置web.xml如下:
+
+```xml
+
+<listener>
+  <listener-class>com.weibo.api.motan.protocol.restful.support.servlet.RestfulServletContainerListener</listener-class>
+</listener>
+
+<servlet>
+  <servlet-name>dispatcher</servlet-name>
+    <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
+    <load-on-startup>1</load-on-startup>
+    <init-param>
+      <param-name>resteasy.servlet.mapping.prefix</param-name>
+      <param-value>/servlet</param-value>  <!-- 此处实际为servlet-mapping的url-pattern，具体配置见resteasy文档-->
+    </init-param>
+</servlet>
+
+<servlet-mapping>
+  <servlet-name>dispatcher</servlet-name>
+  <url-pattern>/servlet/*</url-pattern>
+</servlet-mapping>
+```
+
+此时如果使用rpc客户端，则需要注意contextpath配置：`<motan:protocol name="restful" contextpath="/serverContextPath/dispatcherServletUrlPattern" />`,
+加入服务端部署的ContextPath为`/myserver`,servlet的url-pattern为`/servlet/*`,则客户端的contextpath则应配置为`/myserver/servlet`

--- a/motan-extension/protocol-extension/motan-protocol-restful/restful.md
+++ b/motan-extension/protocol-extension/motan-protocol-restful/restful.md
@@ -75,6 +75,7 @@ public class RestHelloResource implements HelloResource{
 
 ```xml
 
+<!-- 此filter必须在spring ContextLoaderFilter之前 -->
 <listener>
   <listener-class>com.weibo.api.motan.protocol.restful.support.servlet.RestfulServletContainerListener</listener-class>
 </listener>
@@ -96,4 +97,4 @@ public class RestHelloResource implements HelloResource{
 ```
 
 此时如果使用rpc客户端，则需要注意contextpath配置：`<motan:protocol name="restful" contextpath="/serverContextPath/dispatcherServletUrlPattern" />`,
-加入服务端部署的ContextPath为`/myserver`,servlet的url-pattern为`/servlet/*`,则客户端的contextpath则应配置为`/myserver/servlet`
+假如服务端部署的ContextPath为`/myserver`,servlet的url-pattern为`/servlet/*`,则客户端的contextpath则应配置为`/myserver/servlet`

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/EmbedRestServer.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/EmbedRestServer.java
@@ -25,24 +25,24 @@ import org.jboss.resteasy.spi.ResteasyDeployment;
  *
  */
 public class EmbedRestServer implements RestServer {
-	private EmbeddedJaxrsServer server;
+    private EmbeddedJaxrsServer server;
 
-	public EmbedRestServer(EmbeddedJaxrsServer server) {
-		this.server = server;
-	}
+    public EmbedRestServer(EmbeddedJaxrsServer server) {
+        this.server = server;
+    }
 
-	@Override
-	public ResteasyDeployment getDeployment() {
-		return server.getDeployment();
-	}
+    @Override
+    public ResteasyDeployment getDeployment() {
+        return server.getDeployment();
+    }
 
-	@Override
-	public void start() {
-		server.start();
-	}
+    @Override
+    public void start() {
+        server.start();
+    }
 
-	public void stop() {
-		server.stop();
-	}
+    public void stop() {
+        server.stop();
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/EmbedRestServer.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/EmbedRestServer.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful;
+
+import org.jboss.resteasy.plugins.server.embedded.EmbeddedJaxrsServer;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+
+/**
+ * 内嵌resteasy server
+ *
+ * @author zhouhaocheng
+ *
+ */
+public class EmbedRestServer implements RestServer {
+	private EmbeddedJaxrsServer server;
+
+	public EmbedRestServer(EmbeddedJaxrsServer server) {
+		this.server = server;
+	}
+
+	@Override
+	public ResteasyDeployment getDeployment() {
+		return server.getDeployment();
+	}
+
+	@Override
+	public void start() {
+		server.start();
+	}
+
+	public void stop() {
+		server.stop();
+	}
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/EndpointFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/EndpointFactory.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+
+import com.weibo.api.motan.core.extension.Scope;
+import com.weibo.api.motan.core.extension.Spi;
+import com.weibo.api.motan.rpc.URL;
+
+@Spi(scope = Scope.SINGLETON)
+public interface EndpointFactory {
+
+	RestServer createServer(URL url);
+
+	ResteasyWebTarget createClient(URL url);
+
+	void safeReleaseResource(RestServer server, URL url);
+
+	void safeReleaseResource(ResteasyWebTarget client, URL url);
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/EndpointFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/EndpointFactory.java
@@ -24,12 +24,12 @@ import com.weibo.api.motan.rpc.URL;
 @Spi(scope = Scope.SINGLETON)
 public interface EndpointFactory {
 
-	RestServer createServer(URL url);
+    RestServer createServer(URL url);
 
-	ResteasyWebTarget createClient(URL url);
+    ResteasyWebTarget createClient(URL url);
 
-	void safeReleaseResource(RestServer server, URL url);
+    void safeReleaseResource(RestServer server, URL url);
 
-	void safeReleaseResource(ResteasyWebTarget client, URL url);
+    void safeReleaseResource(ResteasyWebTarget client, URL url);
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/RestServer.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/RestServer.java
@@ -17,12 +17,12 @@ package com.weibo.api.motan.protocol.restful;
 
 import org.jboss.resteasy.spi.ResteasyDeployment;
 
-public interface RestServer{
+public interface RestServer {
 
-  void start();
+    void start();
 
-  ResteasyDeployment getDeployment();
+    ResteasyDeployment getDeployment();
 
-  void stop();
+    void stop();
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/RestServer.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/RestServer.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful;
+
+import org.jboss.resteasy.spi.ResteasyDeployment;
+
+public interface RestServer{
+
+  void start();
+
+  ResteasyDeployment getDeployment();
+
+  void stop();
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/RestfulProtocol.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/RestfulProtocol.java
@@ -1,0 +1,156 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.weibo.api.motan.common.URLParamType;
+import com.weibo.api.motan.core.extension.ExtensionLoader;
+import com.weibo.api.motan.core.extension.SpiMeta;
+import com.weibo.api.motan.protocol.AbstractProtocol;
+import com.weibo.api.motan.protocol.restful.support.ProviderResource;
+import com.weibo.api.motan.protocol.restful.support.RestfulClientResponse;
+import com.weibo.api.motan.protocol.restful.support.RestfulUtil;
+import com.weibo.api.motan.protocol.restful.support.proxy.RestfulClientInvoker;
+import com.weibo.api.motan.protocol.restful.support.proxy.RestfulProxyBuilder;
+import com.weibo.api.motan.rpc.AbstractExporter;
+import com.weibo.api.motan.rpc.AbstractReferer;
+import com.weibo.api.motan.rpc.Exporter;
+import com.weibo.api.motan.rpc.Provider;
+import com.weibo.api.motan.rpc.Referer;
+import com.weibo.api.motan.rpc.Request;
+import com.weibo.api.motan.rpc.Response;
+import com.weibo.api.motan.rpc.URL;
+import com.weibo.api.motan.util.MotanFrameworkUtil;
+import com.weibo.api.motan.util.ReflectUtil;
+
+/**
+ * restful协议
+ *
+ * @author zhouhaocheng
+ *
+ */
+@SpiMeta(name = "restful")
+public class RestfulProtocol extends AbstractProtocol {
+	private static final Logger logger = LoggerFactory.getLogger(RestfulProtocol.class);
+
+	@Override
+	protected <T> Exporter<T> createExporter(Provider<T> provider, URL url) {
+		return new RestfulExporter<T>(provider, url);
+	}
+
+	@Override
+	protected <T> Referer<T> createReferer(Class<T> clz, URL url, URL serviceUrl) {
+		return new RestfulReferer<T>(clz, serviceUrl);
+	}
+
+	private class RestfulExporter<T> extends AbstractExporter<T> {
+		private RestServer server;
+		private EndpointFactory endpointFactory;
+
+		public RestfulExporter(Provider<T> provider, URL url) {
+			super(provider, url);
+
+			endpointFactory = ExtensionLoader.getExtensionLoader(EndpointFactory.class).getExtension(
+					url.getParameter(URLParamType.endpointFactory.getName(), URLParamType.endpointFactory.getValue()));
+			server = endpointFactory.createServer(url);
+		}
+
+		@Override
+		public void unexport() {
+			server.getDeployment().getRegistry().removeRegistrations(provider.getInterface());
+
+			String protocolKey = MotanFrameworkUtil.getProtocolKey(url);
+
+			@SuppressWarnings("unchecked")
+			Exporter<T> exporter = (Exporter<T>) exporterMap.remove(protocolKey);
+
+			if (exporter != null) {
+				exporter.destroy();
+			}
+
+			logger.info("RestfulExporter unexport Success: url={}", url);
+		}
+
+		@Override
+		public void destroy() {
+			endpointFactory.safeReleaseResource(server, url);
+
+			logger.info("RestfulExporter destory Success: url={}", url);
+		}
+
+		@Override
+		protected boolean doInit() {
+			server.getDeployment().getRegistry().addResourceFactory(new ProviderResource<T>(provider));
+			return true;
+		}
+	}
+
+	private static class RestfulReferer<T> extends AbstractReferer<T> {
+		private ResteasyWebTarget target;
+		private EndpointFactory endpointFactory;
+
+		private Map<Method, RestfulClientInvoker> delegate;
+
+		public RestfulReferer(Class<T> clz, URL url) {
+			super(clz, url);
+
+			endpointFactory = ExtensionLoader.getExtensionLoader(EndpointFactory.class).getExtension(
+					url.getParameter(URLParamType.endpointFactory.getName(), URLParamType.endpointFactory.getValue()));
+			target = endpointFactory.createClient(url);
+		}
+
+		@Override
+		public void destroy() {
+			endpointFactory.safeReleaseResource(target, url);
+
+			logger.info("RestfulReferer destory client: url={}" + url);
+		}
+
+		@Override
+		protected Response doCall(Request request) {
+			RestfulClientResponse response = new RestfulClientResponse(request.getRequestId());
+			try {
+				Method method = getInterface().getMethod(request.getMethodName(),
+						ReflectUtil.forNames(request.getParamtersDesc()));
+
+				Object value = delegate.get(method).invoke(request.getArguments(), request, response);
+
+				response.setValue(value);
+			} catch (Exception e) {
+				Exception cause = RestfulUtil.getCause(response.getHttpResponse());
+				response.setException(cause != null ? cause : e);
+			}
+
+			return response;
+		}
+
+		@Override
+		protected boolean doInit() {
+			// 此处不使用target.proxy(getInterface()),否则须使用filter方式来完成request/response中attachment的传递
+			delegate = RestfulProxyBuilder.builder(getInterface(), target).build();
+
+			return true;
+		}
+
+	}
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/RestfulProtocol.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/RestfulProtocol.java
@@ -19,8 +19,6 @@ import java.lang.reflect.Method;
 import java.util.Map;
 
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.weibo.api.motan.common.URLParamType;
 import com.weibo.api.motan.core.extension.ExtensionLoader;
@@ -39,6 +37,7 @@ import com.weibo.api.motan.rpc.Referer;
 import com.weibo.api.motan.rpc.Request;
 import com.weibo.api.motan.rpc.Response;
 import com.weibo.api.motan.rpc.URL;
+import com.weibo.api.motan.util.LoggerUtil;
 import com.weibo.api.motan.util.MotanFrameworkUtil;
 import com.weibo.api.motan.util.ReflectUtil;
 
@@ -50,7 +49,6 @@ import com.weibo.api.motan.util.ReflectUtil;
  */
 @SpiMeta(name = "restful")
 public class RestfulProtocol extends AbstractProtocol {
-	private static final Logger logger = LoggerFactory.getLogger(RestfulProtocol.class);
 
 	@Override
 	protected <T> Exporter<T> createExporter(Provider<T> provider, URL url) {
@@ -87,14 +85,14 @@ public class RestfulProtocol extends AbstractProtocol {
 				exporter.destroy();
 			}
 
-			logger.info("RestfulExporter unexport Success: url={}", url);
+			LoggerUtil.info("RestfulExporter unexport Success: url={}", url);
 		}
 
 		@Override
 		public void destroy() {
 			endpointFactory.safeReleaseResource(server, url);
 
-			logger.info("RestfulExporter destory Success: url={}", url);
+			LoggerUtil.info("RestfulExporter destory Success: url={}", url);
 		}
 
 		@Override
@@ -122,7 +120,7 @@ public class RestfulProtocol extends AbstractProtocol {
 		public void destroy() {
 			endpointFactory.safeReleaseResource(target, url);
 
-			logger.info("RestfulReferer destory client: url={}" + url);
+			LoggerUtil.info("RestfulReferer destory client: url={}" + url);
 		}
 
 		@Override

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/AbstractEndpointFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/AbstractEndpointFactory.java
@@ -24,7 +24,6 @@ import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 
-import com.weibo.api.motan.protocol.restful.EmbedRestServer;
 import com.weibo.api.motan.protocol.restful.EndpointFactory;
 import com.weibo.api.motan.protocol.restful.RestServer;
 import com.weibo.api.motan.rpc.URL;
@@ -33,9 +32,9 @@ import com.weibo.api.motan.util.MotanFrameworkUtil;
 
 public abstract class AbstractEndpointFactory implements EndpointFactory {
 	/** 维持share channel 的service列表 **/
-	protected Map<String, RestServer> ipPort2ServerShareChannel = new HashMap<String, RestServer>();
+	protected final Map<String, RestServer> ipPort2ServerShareChannel = new HashMap<String, RestServer>();
 	// 维持share channel 的client列表 <ip:port,client>
-	private final Map<String, ResteasyWebTarget> ipPort2ClientShareChannel = new HashMap<String, ResteasyWebTarget>();
+	protected final Map<String, ResteasyWebTarget> ipPort2ClientShareChannel = new HashMap<String, ResteasyWebTarget>();
 
 	protected Map<RestServer, Set<String>> server2UrlsShareChannel = new HashMap<RestServer, Set<String>>();
 	protected Map<ResteasyWebTarget, Set<String>> client2UrlsShareChannel = new HashMap<ResteasyWebTarget, Set<String>>();
@@ -60,12 +59,6 @@ public abstract class AbstractEndpointFactory implements EndpointFactory {
 			url.setPath(""); // 共享server端口，由于有多个interfaces存在，所以把path设置为空
 
 			server = innerCreateServer(url);
-
-			// 当rpc系统不是单独启动的进程，而是部署到了Java应用服务器中用，就用RestfulServletContainerListener来设置
-			if (server instanceof EmbedRestServer) {
-				server.getDeployment().setInjectorFactoryClass(RestfulInjectorFactory.class.getName());
-				server.getDeployment().getProviderClasses().add(RpcExceptionMapper.class.getName());
-			}
 
 			server.start();
 

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/AbstractEndpointFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/AbstractEndpointFactory.java
@@ -1,0 +1,171 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful.support;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.resteasy.client.jaxrs.ResteasyClient;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.weibo.api.motan.protocol.restful.EmbedRestServer;
+import com.weibo.api.motan.protocol.restful.EndpointFactory;
+import com.weibo.api.motan.protocol.restful.RestServer;
+import com.weibo.api.motan.rpc.URL;
+import com.weibo.api.motan.util.MotanFrameworkUtil;
+
+public abstract class AbstractEndpointFactory implements EndpointFactory {
+	private static final Logger logger = LoggerFactory.getLogger(AbstractEndpointFactory.class);
+	/** 维持share channel 的service列表 **/
+	protected Map<String, RestServer> ipPort2ServerShareChannel = new HashMap<String, RestServer>();
+	// 维持share channel 的client列表 <ip:port,client>
+	private final Map<String, ResteasyWebTarget> ipPort2ClientShareChannel = new HashMap<String, ResteasyWebTarget>();
+
+	protected Map<RestServer, Set<String>> server2UrlsShareChannel = new HashMap<RestServer, Set<String>>();
+	protected Map<ResteasyWebTarget, Set<String>> client2UrlsShareChannel = new HashMap<ResteasyWebTarget, Set<String>>();
+
+	@Override
+	public RestServer createServer(URL url) {
+		String ipPort = url.getServerPortStr();
+		String protocolKey = MotanFrameworkUtil.getProtocolKey(url);
+
+		logger.info(this.getClass().getSimpleName() + " create share_channel server: url={}", url);
+
+		synchronized (ipPort2ServerShareChannel) {
+			RestServer server = ipPort2ServerShareChannel.get(ipPort);
+
+			if (server != null) {
+				saveEndpoint2Urls(server2UrlsShareChannel, server, protocolKey);
+
+				return server;
+			}
+
+			url = url.createCopy();
+			url.setPath(""); // 共享server端口，由于有多个interfaces存在，所以把path设置为空
+
+			server = innerCreateServer(url);
+
+			// 当rpc系统不是单独启动的进程，而是部署到了Java应用服务器中用，就用RestfulServletContainerListener来设置
+			if (server instanceof EmbedRestServer) {
+				server.getDeployment().setInjectorFactoryClass(RestfulInjectorFactory.class.getName());
+				server.getDeployment().getProviderClasses().add(RpcExceptionMapper.class.getName());
+			}
+
+			server.start();
+
+			ipPort2ServerShareChannel.put(ipPort, server);
+			saveEndpoint2Urls(server2UrlsShareChannel, server, protocolKey);
+
+			return server;
+		}
+	}
+
+	@Override
+	public ResteasyWebTarget createClient(URL url) {
+		String ipPort = url.getServerPortStr();
+		String protocolKey = MotanFrameworkUtil.getProtocolKey(url);
+
+		logger.info(this.getClass().getSimpleName() + " create share_channel client: url={}", url);
+
+		synchronized (ipPort2ClientShareChannel) {
+			ResteasyWebTarget client = ipPort2ClientShareChannel.get(ipPort);
+
+			if (client != null) {
+				saveEndpoint2Urls(client2UrlsShareChannel, client, protocolKey);
+				return client;
+			}
+
+			client = innerCreateClient(url);
+
+			ipPort2ClientShareChannel.put(ipPort, client);
+			saveEndpoint2Urls(client2UrlsShareChannel, client, protocolKey);
+
+			return client;
+		}
+	}
+
+	@Override
+	public void safeReleaseResource(RestServer server, URL url) {
+		String ipPort = url.getServerPortStr();
+		String protocolKey = MotanFrameworkUtil.getProtocolKey(url);
+
+		synchronized (ipPort2ServerShareChannel) {
+			if (server != ipPort2ServerShareChannel.get(ipPort)) {
+				server.stop();
+				return;
+			}
+
+			Set<String> urls = server2UrlsShareChannel.get(server);
+			urls.remove(protocolKey);
+
+			if (urls.isEmpty()) {
+				server.stop();
+				ipPort2ServerShareChannel.remove(ipPort);
+				server2UrlsShareChannel.remove(server);
+			}
+		}
+	}
+
+	@Override
+	public void safeReleaseResource(ResteasyWebTarget client, URL url) {
+		String ipPort = url.getServerPortStr();
+		String protocolKey = MotanFrameworkUtil.getProtocolKey(url);
+
+		synchronized (ipPort2ClientShareChannel) {
+			if (client != ipPort2ClientShareChannel.get(ipPort)) {
+				client.getResteasyClient().close();
+				return;
+			}
+
+			Set<String> urls = client2UrlsShareChannel.get(client);
+			urls.remove(protocolKey);
+
+			if (urls.isEmpty()) {
+				client.getResteasyClient().close();
+				ipPort2ClientShareChannel.remove(ipPort);
+				client2UrlsShareChannel.remove(client);
+			}
+		}
+	}
+
+	private <T> void saveEndpoint2Urls(Map<T, Set<String>> map, T endpoint, String protocolKey) {
+		Set<String> sets = map.get(endpoint);
+
+		if (sets == null) {
+			sets = new HashSet<String>();
+			map.put(endpoint, sets);
+		}
+
+		sets.add(protocolKey);
+	}
+
+	protected abstract RestServer innerCreateServer(URL url);
+
+	protected ResteasyWebTarget innerCreateClient(URL url) {
+		ResteasyClient client = new ResteasyClientBuilder().build();
+		String contextpath = url.getParameter("contextpath", "/");
+		if (!contextpath.startsWith("/"))
+			contextpath = "/" + contextpath;
+
+		return client.target("http://" + url.getHost() + ":" + url.getPort() + contextpath);
+	}
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/AbstractEndpointFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/AbstractEndpointFactory.java
@@ -31,132 +31,132 @@ import com.weibo.api.motan.util.LoggerUtil;
 import com.weibo.api.motan.util.MotanFrameworkUtil;
 
 public abstract class AbstractEndpointFactory implements EndpointFactory {
-	/** 维持share channel 的service列表 **/
-	protected final Map<String, RestServer> ipPort2ServerShareChannel = new HashMap<String, RestServer>();
-	// 维持share channel 的client列表 <ip:port,client>
-	protected final Map<String, ResteasyWebTarget> ipPort2ClientShareChannel = new HashMap<String, ResteasyWebTarget>();
+    /** 维持share channel 的service列表 **/
+    protected final Map<String, RestServer> ipPort2ServerShareChannel = new HashMap<String, RestServer>();
+    // 维持share channel 的client列表 <ip:port,client>
+    protected final Map<String, ResteasyWebTarget> ipPort2ClientShareChannel = new HashMap<String, ResteasyWebTarget>();
 
-	protected Map<RestServer, Set<String>> server2UrlsShareChannel = new HashMap<RestServer, Set<String>>();
-	protected Map<ResteasyWebTarget, Set<String>> client2UrlsShareChannel = new HashMap<ResteasyWebTarget, Set<String>>();
+    protected Map<RestServer, Set<String>> server2UrlsShareChannel = new HashMap<RestServer, Set<String>>();
+    protected Map<ResteasyWebTarget, Set<String>> client2UrlsShareChannel = new HashMap<ResteasyWebTarget, Set<String>>();
 
-	@Override
-	public RestServer createServer(URL url) {
-		String ipPort = url.getServerPortStr();
-		String protocolKey = MotanFrameworkUtil.getProtocolKey(url);
+    @Override
+    public RestServer createServer(URL url) {
+        String ipPort = url.getServerPortStr();
+        String protocolKey = MotanFrameworkUtil.getProtocolKey(url);
 
-		LoggerUtil.info(this.getClass().getSimpleName() + " create share_channel server: url={}", url);
+        LoggerUtil.info(this.getClass().getSimpleName() + " create share_channel server: url={}", url);
 
-		synchronized (ipPort2ServerShareChannel) {
-			RestServer server = ipPort2ServerShareChannel.get(ipPort);
+        synchronized (ipPort2ServerShareChannel) {
+            RestServer server = ipPort2ServerShareChannel.get(ipPort);
 
-			if (server != null) {
-				saveEndpoint2Urls(server2UrlsShareChannel, server, protocolKey);
+            if (server != null) {
+                saveEndpoint2Urls(server2UrlsShareChannel, server, protocolKey);
 
-				return server;
-			}
+                return server;
+            }
 
-			url = url.createCopy();
-			url.setPath(""); // 共享server端口，由于有多个interfaces存在，所以把path设置为空
+            url = url.createCopy();
+            url.setPath(""); // 共享server端口，由于有多个interfaces存在，所以把path设置为空
 
-			server = innerCreateServer(url);
+            server = innerCreateServer(url);
 
-			server.start();
+            server.start();
 
-			ipPort2ServerShareChannel.put(ipPort, server);
-			saveEndpoint2Urls(server2UrlsShareChannel, server, protocolKey);
+            ipPort2ServerShareChannel.put(ipPort, server);
+            saveEndpoint2Urls(server2UrlsShareChannel, server, protocolKey);
 
-			return server;
-		}
-	}
+            return server;
+        }
+    }
 
-	@Override
-	public ResteasyWebTarget createClient(URL url) {
-		String ipPort = url.getServerPortStr();
-		String protocolKey = MotanFrameworkUtil.getProtocolKey(url);
+    @Override
+    public ResteasyWebTarget createClient(URL url) {
+        String ipPort = url.getServerPortStr();
+        String protocolKey = MotanFrameworkUtil.getProtocolKey(url);
 
-		LoggerUtil.info(this.getClass().getSimpleName() + " create share_channel client: url={}", url);
+        LoggerUtil.info(this.getClass().getSimpleName() + " create share_channel client: url={}", url);
 
-		synchronized (ipPort2ClientShareChannel) {
-			ResteasyWebTarget client = ipPort2ClientShareChannel.get(ipPort);
+        synchronized (ipPort2ClientShareChannel) {
+            ResteasyWebTarget client = ipPort2ClientShareChannel.get(ipPort);
 
-			if (client != null) {
-				saveEndpoint2Urls(client2UrlsShareChannel, client, protocolKey);
-				return client;
-			}
+            if (client != null) {
+                saveEndpoint2Urls(client2UrlsShareChannel, client, protocolKey);
+                return client;
+            }
 
-			client = innerCreateClient(url);
+            client = innerCreateClient(url);
 
-			ipPort2ClientShareChannel.put(ipPort, client);
-			saveEndpoint2Urls(client2UrlsShareChannel, client, protocolKey);
+            ipPort2ClientShareChannel.put(ipPort, client);
+            saveEndpoint2Urls(client2UrlsShareChannel, client, protocolKey);
 
-			return client;
-		}
-	}
+            return client;
+        }
+    }
 
-	@Override
-	public void safeReleaseResource(RestServer server, URL url) {
-		String ipPort = url.getServerPortStr();
-		String protocolKey = MotanFrameworkUtil.getProtocolKey(url);
+    @Override
+    public void safeReleaseResource(RestServer server, URL url) {
+        String ipPort = url.getServerPortStr();
+        String protocolKey = MotanFrameworkUtil.getProtocolKey(url);
 
-		synchronized (ipPort2ServerShareChannel) {
-			if (server != ipPort2ServerShareChannel.get(ipPort)) {
-				server.stop();
-				return;
-			}
+        synchronized (ipPort2ServerShareChannel) {
+            if (server != ipPort2ServerShareChannel.get(ipPort)) {
+                server.stop();
+                return;
+            }
 
-			Set<String> urls = server2UrlsShareChannel.get(server);
-			urls.remove(protocolKey);
+            Set<String> urls = server2UrlsShareChannel.get(server);
+            urls.remove(protocolKey);
 
-			if (urls.isEmpty()) {
-				server.stop();
-				ipPort2ServerShareChannel.remove(ipPort);
-				server2UrlsShareChannel.remove(server);
-			}
-		}
-	}
+            if (urls.isEmpty()) {
+                server.stop();
+                ipPort2ServerShareChannel.remove(ipPort);
+                server2UrlsShareChannel.remove(server);
+            }
+        }
+    }
 
-	@Override
-	public void safeReleaseResource(ResteasyWebTarget client, URL url) {
-		String ipPort = url.getServerPortStr();
-		String protocolKey = MotanFrameworkUtil.getProtocolKey(url);
+    @Override
+    public void safeReleaseResource(ResteasyWebTarget client, URL url) {
+        String ipPort = url.getServerPortStr();
+        String protocolKey = MotanFrameworkUtil.getProtocolKey(url);
 
-		synchronized (ipPort2ClientShareChannel) {
-			if (client != ipPort2ClientShareChannel.get(ipPort)) {
-				client.getResteasyClient().close();
-				return;
-			}
+        synchronized (ipPort2ClientShareChannel) {
+            if (client != ipPort2ClientShareChannel.get(ipPort)) {
+                client.getResteasyClient().close();
+                return;
+            }
 
-			Set<String> urls = client2UrlsShareChannel.get(client);
-			urls.remove(protocolKey);
+            Set<String> urls = client2UrlsShareChannel.get(client);
+            urls.remove(protocolKey);
 
-			if (urls.isEmpty()) {
-				client.getResteasyClient().close();
-				ipPort2ClientShareChannel.remove(ipPort);
-				client2UrlsShareChannel.remove(client);
-			}
-		}
-	}
+            if (urls.isEmpty()) {
+                client.getResteasyClient().close();
+                ipPort2ClientShareChannel.remove(ipPort);
+                client2UrlsShareChannel.remove(client);
+            }
+        }
+    }
 
-	private <T> void saveEndpoint2Urls(Map<T, Set<String>> map, T endpoint, String protocolKey) {
-		Set<String> sets = map.get(endpoint);
+    private <T> void saveEndpoint2Urls(Map<T, Set<String>> map, T endpoint, String protocolKey) {
+        Set<String> sets = map.get(endpoint);
 
-		if (sets == null) {
-			sets = new HashSet<String>();
-			map.put(endpoint, sets);
-		}
+        if (sets == null) {
+            sets = new HashSet<String>();
+            map.put(endpoint, sets);
+        }
 
-		sets.add(protocolKey);
-	}
+        sets.add(protocolKey);
+    }
 
-	protected abstract RestServer innerCreateServer(URL url);
+    protected abstract RestServer innerCreateServer(URL url);
 
-	protected ResteasyWebTarget innerCreateClient(URL url) {
-		ResteasyClient client = new ResteasyClientBuilder().build();
-		String contextpath = url.getParameter("contextpath", "/");
-		if (!contextpath.startsWith("/"))
-			contextpath = "/" + contextpath;
+    protected ResteasyWebTarget innerCreateClient(URL url) {
+        ResteasyClient client = new ResteasyClientBuilder().build();
+        String contextpath = url.getParameter("contextpath", "/");
+        if (!contextpath.startsWith("/"))
+            contextpath = "/" + contextpath;
 
-		return client.target("http://" + url.getHost() + ":" + url.getPort() + contextpath);
-	}
+        return client.target("http://" + url.getHost() + ":" + url.getPort() + contextpath);
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/AbstractEndpointFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/AbstractEndpointFactory.java
@@ -23,17 +23,15 @@ import java.util.Set;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.weibo.api.motan.protocol.restful.EmbedRestServer;
 import com.weibo.api.motan.protocol.restful.EndpointFactory;
 import com.weibo.api.motan.protocol.restful.RestServer;
 import com.weibo.api.motan.rpc.URL;
+import com.weibo.api.motan.util.LoggerUtil;
 import com.weibo.api.motan.util.MotanFrameworkUtil;
 
 public abstract class AbstractEndpointFactory implements EndpointFactory {
-	private static final Logger logger = LoggerFactory.getLogger(AbstractEndpointFactory.class);
 	/** 维持share channel 的service列表 **/
 	protected Map<String, RestServer> ipPort2ServerShareChannel = new HashMap<String, RestServer>();
 	// 维持share channel 的client列表 <ip:port,client>
@@ -47,7 +45,7 @@ public abstract class AbstractEndpointFactory implements EndpointFactory {
 		String ipPort = url.getServerPortStr();
 		String protocolKey = MotanFrameworkUtil.getProtocolKey(url);
 
-		logger.info(this.getClass().getSimpleName() + " create share_channel server: url={}", url);
+		LoggerUtil.info(this.getClass().getSimpleName() + " create share_channel server: url={}", url);
 
 		synchronized (ipPort2ServerShareChannel) {
 			RestServer server = ipPort2ServerShareChannel.get(ipPort);
@@ -83,7 +81,7 @@ public abstract class AbstractEndpointFactory implements EndpointFactory {
 		String ipPort = url.getServerPortStr();
 		String protocolKey = MotanFrameworkUtil.getProtocolKey(url);
 
-		logger.info(this.getClass().getSimpleName() + " create share_channel client: url={}", url);
+		LoggerUtil.info(this.getClass().getSimpleName() + " create share_channel client: url={}", url);
 
 		synchronized (ipPort2ClientShareChannel) {
 			ResteasyWebTarget client = ipPort2ClientShareChannel.get(ipPort);

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/ProviderResource.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/ProviderResource.java
@@ -32,30 +32,30 @@ import com.weibo.api.motan.rpc.Provider;
  * @param <T>
  */
 public class ProviderResource<T> implements ResourceFactory {
-	private final Provider<T> provider;
-	private final ResourceClass resourceClass;
+    private final Provider<T> provider;
+    private final ResourceClass resourceClass;
 
-	public ProviderResource(Provider<T> provider) {
-		this.provider = provider;
-		this.resourceClass = ResourceBuilder.rootResourceFromAnnotations(provider.getImpl().getClass());
-	}
+    public ProviderResource(Provider<T> provider) {
+        this.provider = provider;
+        this.resourceClass = ResourceBuilder.rootResourceFromAnnotations(provider.getImpl().getClass());
+    }
 
-	public void registered(ResteasyProviderFactory factory) {
-		factory.getInjectorFactory().createPropertyInjector(resourceClass, factory).inject(provider.getImpl());
-	}
+    public void registered(ResteasyProviderFactory factory) {
+        factory.getInjectorFactory().createPropertyInjector(resourceClass, factory).inject(provider.getImpl());
+    }
 
-	public Object createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory) {
-		return provider;
-	}
+    public Object createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory) {
+        return provider;
+    }
 
-	public void unregistered() {
-	}
+    public void unregistered() {
+    }
 
-	public Class<?> getScannableClass() {
-		return provider.getImpl().getClass();
-	}
+    public Class<?> getScannableClass() {
+        return provider.getImpl().getClass();
+    }
 
-	public void requestFinished(HttpRequest request, HttpResponse response, Object resource) {
-	}
+    public void requestFinished(HttpRequest request, HttpResponse response, Object resource) {
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/ProviderResource.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/ProviderResource.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful.support;
+
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.jboss.resteasy.spi.ResourceFactory;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.metadata.ResourceBuilder;
+import org.jboss.resteasy.spi.metadata.ResourceClass;
+
+import com.weibo.api.motan.rpc.Provider;
+
+/**
+ * 基于provider的resource
+ *
+ * @author zhouhaocheng
+ *
+ * @param <T>
+ */
+public class ProviderResource<T> implements ResourceFactory {
+	private final Provider<T> provider;
+	private final ResourceClass resourceClass;
+
+	public ProviderResource(Provider<T> provider) {
+		this.provider = provider;
+		this.resourceClass = ResourceBuilder.rootResourceFromAnnotations(provider.getImpl().getClass());
+	}
+
+	public void registered(ResteasyProviderFactory factory) {
+		factory.getInjectorFactory().createPropertyInjector(resourceClass, factory).inject(provider.getImpl());
+	}
+
+	public Object createResource(HttpRequest request, HttpResponse response, ResteasyProviderFactory factory) {
+		return provider;
+	}
+
+	public void unregistered() {
+	}
+
+	public Class<?> getScannableClass() {
+		return provider.getImpl().getClass();
+	}
+
+	public void requestFinished(HttpRequest request, HttpResponse response, Object resource) {
+	}
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulClientResponse.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulClientResponse.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful.support;
+
+import org.jboss.resteasy.specimpl.BuiltResponse;
+
+import com.weibo.api.motan.rpc.DefaultResponse;
+
+public class RestfulClientResponse extends DefaultResponse {
+	private static final long serialVersionUID = 1L;
+
+	private BuiltResponse httpResponse;
+
+	public RestfulClientResponse() {
+	}
+
+	public RestfulClientResponse(long requestId) {
+		super(requestId);
+	}
+
+	public void setHttpResponse(BuiltResponse httpResponse) {
+		this.httpResponse = httpResponse;
+	}
+
+	public BuiltResponse getHttpResponse() {
+		return httpResponse;
+	}
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulClientResponse.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulClientResponse.java
@@ -20,23 +20,23 @@ import org.jboss.resteasy.specimpl.BuiltResponse;
 import com.weibo.api.motan.rpc.DefaultResponse;
 
 public class RestfulClientResponse extends DefaultResponse {
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = -2780120101690526109L;
 
-	private BuiltResponse httpResponse;
+    private BuiltResponse httpResponse;
 
-	public RestfulClientResponse() {
-	}
+    public RestfulClientResponse() {
+    }
 
-	public RestfulClientResponse(long requestId) {
-		super(requestId);
-	}
+    public RestfulClientResponse(long requestId) {
+        super(requestId);
+    }
 
-	public void setHttpResponse(BuiltResponse httpResponse) {
-		this.httpResponse = httpResponse;
-	}
+    public void setHttpResponse(BuiltResponse httpResponse) {
+        this.httpResponse = httpResponse;
+    }
 
-	public BuiltResponse getHttpResponse() {
-		return httpResponse;
-	}
+    public BuiltResponse getHttpResponse() {
+        return httpResponse;
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulContainerRequest.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulContainerRequest.java
@@ -26,16 +26,16 @@ import com.weibo.api.motan.rpc.DefaultRequest;
  *
  */
 public class RestfulContainerRequest extends DefaultRequest {
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 5226548801729702089L;
 
-	private HttpRequest httpRequest;
+    private HttpRequest httpRequest;
 
-	public void setHttpRequest(HttpRequest httpRequest) {
-		this.httpRequest = httpRequest;
-	}
+    public void setHttpRequest(HttpRequest httpRequest) {
+        this.httpRequest = httpRequest;
+    }
 
-	public HttpRequest getHttpRequest() {
-		return httpRequest;
-	}
+    public HttpRequest getHttpRequest() {
+        return httpRequest;
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulContainerRequest.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulContainerRequest.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful.support;
+
+import org.jboss.resteasy.spi.HttpRequest;
+
+import com.weibo.api.motan.rpc.DefaultRequest;
+
+/**
+ * 服务端接收到的rpc request
+ *
+ * @author zhouhaocheng
+ *
+ */
+public class RestfulContainerRequest extends DefaultRequest {
+	private static final long serialVersionUID = 1L;
+
+	private HttpRequest httpRequest;
+
+	public void setHttpRequest(HttpRequest httpRequest) {
+		this.httpRequest = httpRequest;
+	}
+
+	public HttpRequest getHttpRequest() {
+		return httpRequest;
+	}
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulInjectorFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulInjectorFactory.java
@@ -69,9 +69,8 @@ public class RestfulInjectorFactory extends InjectorFactoryImpl{
 
         return resp.getValue();
       }catch(Exception e){
-        Throwable cause = e.getCause();
-        if(cause != null && cause instanceof RuntimeException){
-          throw (RuntimeException) cause;
+        if(e != null && e instanceof RuntimeException){
+          throw (RuntimeException) e;
         }
 
         throw new InternalServerErrorException("provider call process error:" + e.getMessage(), e);

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulInjectorFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulInjectorFactory.java
@@ -31,52 +31,52 @@ import com.weibo.api.motan.rpc.Provider;
 import com.weibo.api.motan.rpc.Response;
 import com.weibo.api.motan.util.ReflectUtil;
 
-public class RestfulInjectorFactory extends InjectorFactoryImpl{
-
-  @Override
-  public MethodInjector createMethodInjector(ResourceLocator method, ResteasyProviderFactory factory){
-    return new RestfulMethodInjector(method, factory);
-  }
-
-  private static class RestfulMethodInjector extends MethodInjectorImpl{
-
-    public RestfulMethodInjector(ResourceLocator resourceMethod, ResteasyProviderFactory factory){
-      super(resourceMethod, factory);
-    }
+public class RestfulInjectorFactory extends InjectorFactoryImpl {
 
     @Override
-    public Object invoke(HttpRequest request, HttpResponse httpResponse, Object resource)
-        throws Failure, ApplicationException{
-      if(!Provider.class.isInstance(resource)){
-        return super.invoke(request, httpResponse, resource);
-      }
-
-      Object[] args = injectArguments(request, httpResponse);
-
-      RestfulContainerRequest req = new RestfulContainerRequest();
-      req.setInterfaceName(method.getResourceClass().getClazz().getName());
-      req.setMethodName(method.getMethod().getName());
-      req.setParamtersDesc(ReflectUtil.getMethodParamDesc(method.getMethod()));
-      req.setArguments(args);
-
-      req.setHttpRequest(request);
-      req.setAttachments(RestfulUtil.decodeAttachments(request.getMutableHeaders()));
-
-      try{
-        Response resp = Provider.class.cast(resource).call(req);
-
-        RestfulUtil.encodeAttachments(httpResponse.getOutputHeaders(), resp.getAttachments());
-
-        return resp.getValue();
-      }catch(Exception e){
-        if(e != null && e instanceof RuntimeException){
-          throw (RuntimeException) e;
-        }
-
-        throw new InternalServerErrorException("provider call process error:" + e.getMessage(), e);
-      }
+    public MethodInjector createMethodInjector(ResourceLocator method, ResteasyProviderFactory factory) {
+        return new RestfulMethodInjector(method, factory);
     }
 
-  }
+    private static class RestfulMethodInjector extends MethodInjectorImpl {
+
+        public RestfulMethodInjector(ResourceLocator resourceMethod, ResteasyProviderFactory factory) {
+            super(resourceMethod, factory);
+        }
+
+        @Override
+        public Object invoke(HttpRequest request, HttpResponse httpResponse, Object resource)
+                throws Failure, ApplicationException {
+            if (!Provider.class.isInstance(resource)) {
+                return super.invoke(request, httpResponse, resource);
+            }
+
+            Object[] args = injectArguments(request, httpResponse);
+
+            RestfulContainerRequest req = new RestfulContainerRequest();
+            req.setInterfaceName(method.getResourceClass().getClazz().getName());
+            req.setMethodName(method.getMethod().getName());
+            req.setParamtersDesc(ReflectUtil.getMethodParamDesc(method.getMethod()));
+            req.setArguments(args);
+
+            req.setHttpRequest(request);
+            req.setAttachments(RestfulUtil.decodeAttachments(request.getMutableHeaders()));
+
+            try {
+                Response resp = Provider.class.cast(resource).call(req);
+
+                RestfulUtil.encodeAttachments(httpResponse.getOutputHeaders(), resp.getAttachments());
+
+                return resp.getValue();
+            } catch (Exception e) {
+                if (e != null && e instanceof RuntimeException) {
+                    throw (RuntimeException) e;
+                }
+
+                throw new InternalServerErrorException("provider call process error:" + e.getMessage(), e);
+            }
+        }
+
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulInjectorFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulInjectorFactory.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful.support;
+
+import javax.ws.rs.InternalServerErrorException;
+
+import org.jboss.resteasy.core.InjectorFactoryImpl;
+import org.jboss.resteasy.core.MethodInjectorImpl;
+import org.jboss.resteasy.spi.ApplicationException;
+import org.jboss.resteasy.spi.Failure;
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.HttpResponse;
+import org.jboss.resteasy.spi.MethodInjector;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+import org.jboss.resteasy.spi.metadata.ResourceLocator;
+
+import com.weibo.api.motan.rpc.Provider;
+import com.weibo.api.motan.rpc.Response;
+import com.weibo.api.motan.util.ReflectUtil;
+
+public class RestfulInjectorFactory extends InjectorFactoryImpl{
+
+  @Override
+  public MethodInjector createMethodInjector(ResourceLocator method, ResteasyProviderFactory factory){
+    return new RestfulMethodInjector(method, factory);
+  }
+
+  private static class RestfulMethodInjector extends MethodInjectorImpl{
+
+    public RestfulMethodInjector(ResourceLocator resourceMethod, ResteasyProviderFactory factory){
+      super(resourceMethod, factory);
+    }
+
+    @Override
+    public Object invoke(HttpRequest request, HttpResponse httpResponse, Object resource)
+        throws Failure, ApplicationException{
+      if(!Provider.class.isInstance(resource)){
+        return super.invoke(request, httpResponse, resource);
+      }
+
+      Object[] args = injectArguments(request, httpResponse);
+
+      RestfulContainerRequest req = new RestfulContainerRequest();
+      req.setInterfaceName(method.getResourceClass().getClazz().getName());
+      req.setMethodName(method.getMethod().getName());
+      req.setParamtersDesc(ReflectUtil.getMethodParamDesc(method.getMethod()));
+      req.setArguments(args);
+
+      req.setHttpRequest(request);
+      req.setAttachments(RestfulUtil.decodeAttachments(request.getMutableHeaders()));
+
+      try{
+        Response resp = Provider.class.cast(resource).call(req);
+
+        RestfulUtil.encodeAttachments(httpResponse.getOutputHeaders(), resp.getAttachments());
+
+        return resp.getValue();
+      }catch(Exception e){
+        Throwable cause = e.getCause();
+        if(cause != null && cause instanceof RuntimeException){
+          throw (RuntimeException) cause;
+        }
+
+        throw new InternalServerErrorException("provider call process error:" + e.getMessage(), e);
+      }
+    }
+
+  }
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulUtil.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulUtil.java
@@ -37,84 +37,84 @@ import com.weibo.api.motan.util.LoggerUtil;
 import com.weibo.api.motan.util.StringTools;
 
 public class RestfulUtil {
-	public static final String ATTACHMENT_HEADER = "X-Attach";
-	public static final String EXCEPTION_HEADER = "X-Exception";
+    public static final String ATTACHMENT_HEADER = "X-Attach";
+    public static final String EXCEPTION_HEADER = "X-Exception";
 
-	public static boolean isRpcRequest(MultivaluedMap<String, String> headers) {
-		return headers != null && headers.containsKey(ATTACHMENT_HEADER);
-	}
+    public static boolean isRpcRequest(MultivaluedMap<String, String> headers) {
+        return headers != null && headers.containsKey(ATTACHMENT_HEADER);
+    }
 
-	public static void encodeAttachments(MultivaluedMap<String, Object> headers, Map<String, String> attachments) {
-		if (attachments == null || attachments.isEmpty())
-			return;
+    public static void encodeAttachments(MultivaluedMap<String, Object> headers, Map<String, String> attachments) {
+        if (attachments == null || attachments.isEmpty())
+            return;
 
-		StringBuilder value = new StringBuilder();
-		for (Map.Entry<String, String> entry : attachments.entrySet()) {
-			value.append(StringTools.urlEncode(entry.getKey())).append("=")
-					.append(StringTools.urlEncode(entry.getValue())).append(";");
-		}
+        StringBuilder value = new StringBuilder();
+        for (Map.Entry<String, String> entry : attachments.entrySet()) {
+            value.append(StringTools.urlEncode(entry.getKey())).append("=")
+                    .append(StringTools.urlEncode(entry.getValue())).append(";");
+        }
 
-		if (value.length() > 1)
-			value.deleteCharAt(value.length() - 1);
+        if (value.length() > 1)
+            value.deleteCharAt(value.length() - 1);
 
-		headers.add(ATTACHMENT_HEADER, value.toString());
-	}
+        headers.add(ATTACHMENT_HEADER, value.toString());
+    }
 
-	public static Map<String, String> decodeAttachments(MultivaluedMap<String, String> headers) {
-		String value = headers.getFirst(ATTACHMENT_HEADER);
+    public static Map<String, String> decodeAttachments(MultivaluedMap<String, String> headers) {
+        String value = headers.getFirst(ATTACHMENT_HEADER);
 
-		Map<String, String> result = Collections.emptyMap();
-		if (value != null && !value.isEmpty()) {
-			result = new HashMap<String, String>();
-			for (String kv : value.split(";")) {
-				String[] pair = kv.split("=");
-				if (pair.length == 2) {
-					result.put(StringTools.urlDecode(pair[0]), StringTools.urlDecode(pair[1]));
-				}
-			}
-		}
+        Map<String, String> result = Collections.emptyMap();
+        if (value != null && !value.isEmpty()) {
+            result = new HashMap<String, String>();
+            for (String kv : value.split(";")) {
+                String[] pair = kv.split("=");
+                if (pair.length == 2) {
+                    result.put(StringTools.urlDecode(pair[0]), StringTools.urlDecode(pair[1]));
+                }
+            }
+        }
 
-		return result;
-	}
+        return result;
+    }
 
-	public static Response serializeError(Exception ex) {
-		try {
-			ByteArrayOutputStream baos = new ByteArrayOutputStream();
-			ObjectOutputStream oos = new ObjectOutputStream(baos);
-			oos.writeObject(ex);
-			oos.flush();
+    public static Response serializeError(Exception ex) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(ex);
+            oos.flush();
 
-			String info = new String(Base64.encodeBytesToBytes(baos.toByteArray()), MotanConstants.DEFAULT_CHARACTER);
-			return Response.status(Status.EXPECTATION_FAILED).header(EXCEPTION_HEADER, ex.getClass()).entity(info)
-					.build();
-		} catch (IOException e) {
-			LoggerUtil.error("serialize " + ex.getClass() + " error", e);
+            String info = new String(Base64.encodeBytesToBytes(baos.toByteArray()), MotanConstants.DEFAULT_CHARACTER);
+            return Response.status(Status.EXPECTATION_FAILED).header(EXCEPTION_HEADER, ex.getClass()).entity(info)
+                    .build();
+        } catch (IOException e) {
+            LoggerUtil.error("serialize " + ex.getClass() + " error", e);
 
-			return Response.status(Status.INTERNAL_SERVER_ERROR).entity("serialization " + ex.getClass() + " error")
-					.build();
-		}
-	}
+            return Response.status(Status.INTERNAL_SERVER_ERROR).entity("serialization " + ex.getClass() + " error")
+                    .build();
+        }
+    }
 
-	public static Exception getCause(BuiltResponse resp) {
-		if (resp == null || resp.getStatus() != Status.EXPECTATION_FAILED.getStatusCode())
-			return null;
+    public static Exception getCause(BuiltResponse resp) {
+        if (resp == null || resp.getStatus() != Status.EXPECTATION_FAILED.getStatusCode())
+            return null;
 
-		String exceptionClass = resp.getHeaderString(EXCEPTION_HEADER);
-		if (!StringUtils.isBlank(exceptionClass)) {
-			String body = resp.readEntity(String.class);
-			resp.close();
+        String exceptionClass = resp.getHeaderString(EXCEPTION_HEADER);
+        if (!StringUtils.isBlank(exceptionClass)) {
+            String body = resp.readEntity(String.class);
+            resp.close();
 
-			try {
-				ByteArrayInputStream bais = new ByteArrayInputStream(
-						Base64.decode(body.getBytes(MotanConstants.DEFAULT_CHARACTER)));
-				ObjectInputStream ois = new ObjectInputStream(bais);
-				return (Exception) ois.readObject();
-			} catch (Exception e) {
-				LoggerUtil.error("deserialize " + exceptionClass + " error", e);
-			}
-		}
+            try {
+                ByteArrayInputStream bais = new ByteArrayInputStream(
+                        Base64.decode(body.getBytes(MotanConstants.DEFAULT_CHARACTER)));
+                ObjectInputStream ois = new ObjectInputStream(bais);
+                return (Exception) ois.readObject();
+            } catch (Exception e) {
+                LoggerUtil.error("deserialize " + exceptionClass + " error", e);
+            }
+        }
 
-		return null;
-	}
+        return null;
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulUtil.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulUtil.java
@@ -1,0 +1,119 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful.support;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.resteasy.specimpl.BuiltResponse;
+import org.jboss.resteasy.util.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.weibo.api.motan.common.MotanConstants;
+import com.weibo.api.motan.util.StringTools;
+
+public class RestfulUtil {
+	private static final Logger logger = LoggerFactory.getLogger(RestfulUtil.class);
+
+	public static final String ATTACHMENT_HEADER = "X-Attach";
+	public static final String EXCEPTION_HEADER = "X-Exception";
+
+	public static void encodeAttachments(MultivaluedMap<String, Object> headers, Map<String, String> attachments) {
+		if (attachments == null || attachments.isEmpty())
+			return;
+
+		StringBuilder value = new StringBuilder();
+		for (Map.Entry<String, String> entry : attachments.entrySet()) {
+			value.append(StringTools.urlEncode(entry.getKey())).append("=")
+					.append(StringTools.urlEncode(entry.getValue())).append(";");
+		}
+
+		if (value.length() > 1)
+			value.deleteCharAt(value.length() - 1);
+
+		headers.add(ATTACHMENT_HEADER, value.toString());
+	}
+
+	public static Map<String, String> decodeAttachments(MultivaluedMap<String, String> headers) {
+		String value = headers.getFirst(ATTACHMENT_HEADER);
+
+		Map<String, String> result = Collections.emptyMap();
+		if (value != null && !value.isEmpty()) {
+			result = new HashMap<String, String>();
+			for (String kv : value.split(";")) {
+				String[] pair = kv.split("=");
+				if (pair.length == 2) {
+					result.put(StringTools.urlDecode(pair[0]), StringTools.urlDecode(pair[1]));
+				}
+			}
+		}
+
+		return result;
+	}
+
+	public static Response serializeError(Exception ex) {
+		try {
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			ObjectOutputStream oos = new ObjectOutputStream(baos);
+			oos.writeObject(ex);
+			oos.flush();
+
+			String info = new String(Base64.encodeBytesToBytes(baos.toByteArray()), MotanConstants.DEFAULT_CHARACTER);
+			return Response.status(Status.EXPECTATION_FAILED).header(EXCEPTION_HEADER, ex.getClass()).entity(info)
+					.build();
+		} catch (IOException e) {
+			logger.error("serialize " + ex.getClass() + " error", e);
+
+			return Response.status(Status.INTERNAL_SERVER_ERROR).entity("serialization " + ex.getClass() + " error")
+					.build();
+		}
+	}
+
+	public static Exception getCause(BuiltResponse resp) {
+		if (resp == null || resp.getStatus() != Status.EXPECTATION_FAILED.getStatusCode())
+			return null;
+
+		String exceptionClass = resp.getHeaderString(EXCEPTION_HEADER);
+		if (!StringUtils.isBlank(exceptionClass)) {
+			String body = resp.readEntity(String.class);
+			resp.close();
+
+			try {
+				ByteArrayInputStream bais = new ByteArrayInputStream(
+						Base64.decode(body.getBytes(MotanConstants.DEFAULT_CHARACTER)));
+				ObjectInputStream ois = new ObjectInputStream(bais);
+				return (Exception) ois.readObject();
+			} catch (Exception e) {
+				logger.error("deserialize " + exceptionClass + " error", e);
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulUtil.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulUtil.java
@@ -31,15 +31,12 @@ import javax.ws.rs.core.Response.Status;
 import org.apache.commons.lang3.StringUtils;
 import org.jboss.resteasy.specimpl.BuiltResponse;
 import org.jboss.resteasy.util.Base64;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.weibo.api.motan.common.MotanConstants;
+import com.weibo.api.motan.util.LoggerUtil;
 import com.weibo.api.motan.util.StringTools;
 
 public class RestfulUtil {
-	private static final Logger logger = LoggerFactory.getLogger(RestfulUtil.class);
-
 	public static final String ATTACHMENT_HEADER = "X-Attach";
 	public static final String EXCEPTION_HEADER = "X-Exception";
 
@@ -87,7 +84,7 @@ public class RestfulUtil {
 			return Response.status(Status.EXPECTATION_FAILED).header(EXCEPTION_HEADER, ex.getClass()).entity(info)
 					.build();
 		} catch (IOException e) {
-			logger.error("serialize " + ex.getClass() + " error", e);
+			LoggerUtil.error("serialize " + ex.getClass() + " error", e);
 
 			return Response.status(Status.INTERNAL_SERVER_ERROR).entity("serialization " + ex.getClass() + " error")
 					.build();
@@ -109,7 +106,7 @@ public class RestfulUtil {
 				ObjectInputStream ois = new ObjectInputStream(bais);
 				return (Exception) ois.readObject();
 			} catch (Exception e) {
-				logger.error("deserialize " + exceptionClass + " error", e);
+				LoggerUtil.error("deserialize " + exceptionClass + " error", e);
 			}
 		}
 

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulUtil.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RestfulUtil.java
@@ -40,6 +40,10 @@ public class RestfulUtil {
 	public static final String ATTACHMENT_HEADER = "X-Attach";
 	public static final String EXCEPTION_HEADER = "X-Exception";
 
+	public static boolean isRpcRequest(MultivaluedMap<String, String> headers) {
+		return headers != null && headers.containsKey(ATTACHMENT_HEADER);
+	}
+
 	public static void encodeAttachments(MultivaluedMap<String, Object> headers, Map<String, String> attachments) {
 		if (attachments == null || attachments.isEmpty())
 			return;

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RpcExceptionMapper.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RpcExceptionMapper.java
@@ -22,17 +22,17 @@ import javax.ws.rs.ext.ExceptionMapper;
 import org.jboss.resteasy.spi.HttpRequest;
 import org.jboss.resteasy.spi.ResteasyProviderFactory;
 
-public class RpcExceptionMapper implements ExceptionMapper<Exception>{
+public class RpcExceptionMapper implements ExceptionMapper<Exception> {
 
-  @Override
-  public Response toResponse(Exception exception){
-    HttpRequest httpRequest = ResteasyProviderFactory.getContextData(HttpRequest.class);
-    // 当为rpc调用时,序列化异常
-    if(httpRequest != null & RestfulUtil.isRpcRequest(httpRequest.getMutableHeaders())){
-      return RestfulUtil.serializeError(exception);
+    @Override
+    public Response toResponse(Exception exception) {
+        HttpRequest httpRequest = ResteasyProviderFactory.getContextData(HttpRequest.class);
+        // 当为rpc调用时,序列化异常
+        if (httpRequest != null && RestfulUtil.isRpcRequest(httpRequest.getMutableHeaders())) {
+            return RestfulUtil.serializeError(exception);
+        }
+
+        return Response.status(Status.INTERNAL_SERVER_ERROR).entity(exception.getMessage()).build();
     }
-
-    return Response.status(Status.INTERNAL_SERVER_ERROR).entity(exception.getMessage()).build();
-  }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RpcExceptionMapper.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RpcExceptionMapper.java
@@ -28,7 +28,7 @@ public class RpcExceptionMapper implements ExceptionMapper<Exception>{
   public Response toResponse(Exception exception){
     HttpRequest httpRequest = ResteasyProviderFactory.getContextData(HttpRequest.class);
     // 当为rpc调用时,序列化异常
-    if(httpRequest != null & !RestfulUtil.decodeAttachments(httpRequest.getMutableHeaders()).isEmpty()){
+    if(httpRequest != null & RestfulUtil.isRpcRequest(httpRequest.getMutableHeaders())){
       return RestfulUtil.serializeError(exception);
     }
 

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RpcExceptionMapper.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/RpcExceptionMapper.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful.support;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.jboss.resteasy.spi.HttpRequest;
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
+public class RpcExceptionMapper implements ExceptionMapper<Exception>{
+
+  @Override
+  public Response toResponse(Exception exception){
+    HttpRequest httpRequest = ResteasyProviderFactory.getContextData(HttpRequest.class);
+    // 当为rpc调用时,序列化异常
+    if(httpRequest != null & !RestfulUtil.decodeAttachments(httpRequest.getMutableHeaders()).isEmpty()){
+      return RestfulUtil.serializeError(exception);
+    }
+
+    return Response.status(Status.INTERNAL_SERVER_ERROR).entity(exception.getMessage()).build();
+  }
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/netty/NettyEndpointFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/netty/NettyEndpointFactory.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful.support.netty;
+
+import org.jboss.resteasy.plugins.server.netty.NettyJaxrsServer;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+
+import com.weibo.api.motan.common.URLParamType;
+import com.weibo.api.motan.core.extension.SpiMeta;
+import com.weibo.api.motan.protocol.restful.EmbedRestServer;
+import com.weibo.api.motan.protocol.restful.RestServer;
+import com.weibo.api.motan.protocol.restful.support.AbstractEndpointFactory;
+import com.weibo.api.motan.rpc.URL;
+
+@SpiMeta(name = "netty")
+public class NettyEndpointFactory extends AbstractEndpointFactory {
+
+	@Override
+	protected RestServer innerCreateServer(URL url) {
+		NettyJaxrsServer server = new NettyJaxrsServer();
+		server.setMaxRequestSize(url.getIntParameter(URLParamType.maxContentLength.getName(),
+				URLParamType.maxContentLength.getIntValue()));
+
+		ResteasyDeployment deployment = new ResteasyDeployment();
+
+		server.setDeployment(deployment);
+		server.setExecutorThreadCount(
+				url.getIntParameter(URLParamType.maxWorkerThread.getName(), URLParamType.maxWorkerThread.getIntValue()));
+		server.setPort(url.getPort());
+		server.setRootResourcePath("");
+		server.setSecurityDomain(null);
+
+		return new EmbedRestServer(server);
+	}
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/netty/NettyEndpointFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/netty/NettyEndpointFactory.java
@@ -23,6 +23,8 @@ import com.weibo.api.motan.core.extension.SpiMeta;
 import com.weibo.api.motan.protocol.restful.EmbedRestServer;
 import com.weibo.api.motan.protocol.restful.RestServer;
 import com.weibo.api.motan.protocol.restful.support.AbstractEndpointFactory;
+import com.weibo.api.motan.protocol.restful.support.RestfulInjectorFactory;
+import com.weibo.api.motan.protocol.restful.support.RpcExceptionMapper;
 import com.weibo.api.motan.rpc.URL;
 
 @SpiMeta(name = "netty")
@@ -42,6 +44,9 @@ public class NettyEndpointFactory extends AbstractEndpointFactory {
 		server.setPort(url.getPort());
 		server.setRootResourcePath("");
 		server.setSecurityDomain(null);
+
+		deployment.setInjectorFactoryClass(RestfulInjectorFactory.class.getName());
+		deployment.getProviderClasses().add(RpcExceptionMapper.class.getName());
 
 		return new EmbedRestServer(server);
 	}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/netty/NettyEndpointFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/netty/NettyEndpointFactory.java
@@ -30,25 +30,25 @@ import com.weibo.api.motan.rpc.URL;
 @SpiMeta(name = "netty")
 public class NettyEndpointFactory extends AbstractEndpointFactory {
 
-	@Override
-	protected RestServer innerCreateServer(URL url) {
-		NettyJaxrsServer server = new NettyJaxrsServer();
-		server.setMaxRequestSize(url.getIntParameter(URLParamType.maxContentLength.getName(),
-				URLParamType.maxContentLength.getIntValue()));
+    @Override
+    protected RestServer innerCreateServer(URL url) {
+        NettyJaxrsServer server = new NettyJaxrsServer();
+        server.setMaxRequestSize(url.getIntParameter(URLParamType.maxContentLength.getName(),
+                URLParamType.maxContentLength.getIntValue()));
 
-		ResteasyDeployment deployment = new ResteasyDeployment();
+        ResteasyDeployment deployment = new ResteasyDeployment();
 
-		server.setDeployment(deployment);
-		server.setExecutorThreadCount(
-				url.getIntParameter(URLParamType.maxWorkerThread.getName(), URLParamType.maxWorkerThread.getIntValue()));
-		server.setPort(url.getPort());
-		server.setRootResourcePath("");
-		server.setSecurityDomain(null);
+        server.setDeployment(deployment);
+        server.setExecutorThreadCount(url.getIntParameter(URLParamType.maxWorkerThread.getName(),
+                URLParamType.maxWorkerThread.getIntValue()));
+        server.setPort(url.getPort());
+        server.setRootResourcePath("");
+        server.setSecurityDomain(null);
 
-		deployment.setInjectorFactoryClass(RestfulInjectorFactory.class.getName());
-		deployment.getProviderClasses().add(RpcExceptionMapper.class.getName());
+        deployment.setInjectorFactoryClass(RestfulInjectorFactory.class.getName());
+        deployment.getProviderClasses().add(RpcExceptionMapper.class.getName());
 
-		return new EmbedRestServer(server);
-	}
+        return new EmbedRestServer(server);
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/proxy/RestfulClientInvoker.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/proxy/RestfulClientInvoker.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful.support.proxy;
+
+import java.lang.reflect.Method;
+
+import org.jboss.resteasy.client.jaxrs.ProxyConfig;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
+import org.jboss.resteasy.client.jaxrs.internal.ClientResponse;
+import org.jboss.resteasy.client.jaxrs.internal.proxy.ClientInvoker;
+import org.jboss.resteasy.client.jaxrs.internal.proxy.extractors.ClientContext;
+
+import com.weibo.api.motan.protocol.restful.support.RestfulClientResponse;
+import com.weibo.api.motan.protocol.restful.support.RestfulUtil;
+import com.weibo.api.motan.rpc.Request;
+
+public class RestfulClientInvoker extends ClientInvoker {
+
+	public RestfulClientInvoker(ResteasyWebTarget parent, Class<?> declaring, Method method, ProxyConfig config) {
+		super(parent, declaring, method, config);
+	}
+
+	public Object invoke(Object[] args, Request req, RestfulClientResponse resp) {
+		ClientInvocation request = createRequest(args, req);
+		ClientResponse response = (ClientResponse) request.invoke();
+		resp.setAttachments(RestfulUtil.decodeAttachments(response.getStringHeaders()));
+		resp.setHttpResponse(response);
+
+		ClientContext context = new ClientContext(request, response, entityExtractorFactory);
+		return extractor.extractEntity(context);
+	}
+
+	protected ClientInvocation createRequest(Object[] args, Request request) {
+		ClientInvocation inv = super.createRequest(args);
+		RestfulUtil.encodeAttachments(inv.getHeaders().getHeaders(), request.getAttachments());
+		return inv;
+	}
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/proxy/RestfulClientInvoker.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/proxy/RestfulClientInvoker.java
@@ -30,24 +30,24 @@ import com.weibo.api.motan.rpc.Request;
 
 public class RestfulClientInvoker extends ClientInvoker {
 
-	public RestfulClientInvoker(ResteasyWebTarget parent, Class<?> declaring, Method method, ProxyConfig config) {
-		super(parent, declaring, method, config);
-	}
+    public RestfulClientInvoker(ResteasyWebTarget parent, Class<?> declaring, Method method, ProxyConfig config) {
+        super(parent, declaring, method, config);
+    }
 
-	public Object invoke(Object[] args, Request req, RestfulClientResponse resp) {
-		ClientInvocation request = createRequest(args, req);
-		ClientResponse response = (ClientResponse) request.invoke();
-		resp.setAttachments(RestfulUtil.decodeAttachments(response.getStringHeaders()));
-		resp.setHttpResponse(response);
+    public Object invoke(Object[] args, Request req, RestfulClientResponse resp) {
+        ClientInvocation request = createRequest(args, req);
+        ClientResponse response = (ClientResponse) request.invoke();
+        resp.setAttachments(RestfulUtil.decodeAttachments(response.getStringHeaders()));
+        resp.setHttpResponse(response);
 
-		ClientContext context = new ClientContext(request, response, entityExtractorFactory);
-		return extractor.extractEntity(context);
-	}
+        ClientContext context = new ClientContext(request, response, entityExtractorFactory);
+        return extractor.extractEntity(context);
+    }
 
-	protected ClientInvocation createRequest(Object[] args, Request request) {
-		ClientInvocation inv = super.createRequest(args);
-		RestfulUtil.encodeAttachments(inv.getHeaders().getHeaders(), request.getAttachments());
-		return inv;
-	}
+    protected ClientInvocation createRequest(Object[] args, Request request) {
+        ClientInvocation inv = super.createRequest(args);
+        RestfulUtil.encodeAttachments(inv.getHeaders().getHeaders(), request.getAttachments());
+        return inv;
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/proxy/RestfulProxyBuilder.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/proxy/RestfulProxyBuilder.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful.support.proxy;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+
+import org.jboss.resteasy.client.jaxrs.ProxyConfig;
+import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
+import org.jboss.resteasy.util.IsHttpMethod;
+
+public class RestfulProxyBuilder<T> {
+  private final Class<T> iface;
+  private final ResteasyWebTarget webTarget;
+  private ClassLoader loader = Thread.currentThread().getContextClassLoader();
+  private MediaType serverConsumes;
+  private MediaType serverProduces;
+
+  public static <T> RestfulProxyBuilder<T> builder(Class<T> iface, WebTarget webTarget){
+    return new RestfulProxyBuilder<T>(iface, (ResteasyWebTarget) webTarget);
+  }
+
+  public static Map<Method, RestfulClientInvoker> proxy(final Class<?> iface, WebTarget base, final ProxyConfig config){
+    if(iface.isAnnotationPresent(Path.class)){
+      Path path = iface.getAnnotation(Path.class);
+      if(!path.value().equals("") && !path.value().equals("/")){
+        base = base.path(path.value());
+      }
+    }
+
+    HashMap<Method, RestfulClientInvoker> methodMap = new HashMap<Method, RestfulClientInvoker>();
+    for(Method method : iface.getMethods()){
+      RestfulClientInvoker invoker = createClientInvoker(iface, method, (ResteasyWebTarget) base, config);
+      methodMap.put(method, invoker);
+    }
+
+    return methodMap;
+  }
+
+  private static <T> RestfulClientInvoker createClientInvoker(Class<T> clazz, Method method, ResteasyWebTarget base,
+      ProxyConfig config){
+    Set<String> httpMethods = IsHttpMethod.getHttpMethods(method);
+    if(httpMethods == null || httpMethods.size() != 1){
+      throw new RuntimeException("You must use at least one, but no more than one http method annotation on: " + method.toString());
+    }
+
+    RestfulClientInvoker invoker = new RestfulClientInvoker(base, clazz, method, config);
+    invoker.setHttpMethod(httpMethods.iterator().next());
+    return invoker;
+  }
+
+  private RestfulProxyBuilder(Class<T> iface, ResteasyWebTarget webTarget){
+    this.iface = iface;
+    this.webTarget = webTarget;
+  }
+
+  public RestfulProxyBuilder<T> classloader(ClassLoader cl){
+    this.loader = cl;
+    return this;
+  }
+
+  public RestfulProxyBuilder<T> defaultProduces(MediaType type){
+    this.serverProduces = type;
+    return this;
+  }
+
+  public RestfulProxyBuilder<T> defaultConsumes(MediaType type){
+    this.serverConsumes = type;
+    return this;
+  }
+
+  public RestfulProxyBuilder<T> defaultProduces(String type){
+    this.serverProduces = MediaType.valueOf(type);
+    return this;
+  }
+
+  public RestfulProxyBuilder<T> defaultConsumes(String type){
+    this.serverConsumes = MediaType.valueOf(type);
+    return this;
+  }
+
+  public Map<Method, RestfulClientInvoker> build(){
+    return proxy(iface, webTarget, new ProxyConfig(loader, serverConsumes, serverProduces));
+  }
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/proxy/RestfulProxyBuilder.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/proxy/RestfulProxyBuilder.java
@@ -29,77 +29,79 @@ import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.jboss.resteasy.util.IsHttpMethod;
 
 public class RestfulProxyBuilder<T> {
-  private final Class<T> iface;
-  private final ResteasyWebTarget webTarget;
-  private ClassLoader loader = Thread.currentThread().getContextClassLoader();
-  private MediaType serverConsumes;
-  private MediaType serverProduces;
+    private final Class<T> iface;
+    private final ResteasyWebTarget webTarget;
+    private ClassLoader loader = Thread.currentThread().getContextClassLoader();
+    private MediaType serverConsumes;
+    private MediaType serverProduces;
 
-  public static <T> RestfulProxyBuilder<T> builder(Class<T> iface, WebTarget webTarget){
-    return new RestfulProxyBuilder<T>(iface, (ResteasyWebTarget) webTarget);
-  }
-
-  public static Map<Method, RestfulClientInvoker> proxy(final Class<?> iface, WebTarget base, final ProxyConfig config){
-    if(iface.isAnnotationPresent(Path.class)){
-      Path path = iface.getAnnotation(Path.class);
-      if(!path.value().equals("") && !path.value().equals("/")){
-        base = base.path(path.value());
-      }
+    public static <T> RestfulProxyBuilder<T> builder(Class<T> iface, WebTarget webTarget) {
+        return new RestfulProxyBuilder<T>(iface, (ResteasyWebTarget) webTarget);
     }
 
-    HashMap<Method, RestfulClientInvoker> methodMap = new HashMap<Method, RestfulClientInvoker>();
-    for(Method method : iface.getMethods()){
-      RestfulClientInvoker invoker = createClientInvoker(iface, method, (ResteasyWebTarget) base, config);
-      methodMap.put(method, invoker);
+    public static Map<Method, RestfulClientInvoker> proxy(final Class<?> iface, WebTarget base,
+            final ProxyConfig config) {
+        if (iface.isAnnotationPresent(Path.class)) {
+            Path path = iface.getAnnotation(Path.class);
+            if (!path.value().equals("") && !path.value().equals("/")) {
+                base = base.path(path.value());
+            }
+        }
+
+        HashMap<Method, RestfulClientInvoker> methodMap = new HashMap<Method, RestfulClientInvoker>();
+        for (Method method : iface.getMethods()) {
+            RestfulClientInvoker invoker = createClientInvoker(iface, method, (ResteasyWebTarget) base, config);
+            methodMap.put(method, invoker);
+        }
+
+        return methodMap;
     }
 
-    return methodMap;
-  }
+    private static <T> RestfulClientInvoker createClientInvoker(Class<T> clazz, Method method, ResteasyWebTarget base,
+            ProxyConfig config) {
+        Set<String> httpMethods = IsHttpMethod.getHttpMethods(method);
+        if (httpMethods == null || httpMethods.size() != 1) {
+            throw new RuntimeException(
+                    "You must use at least one, but no more than one http method annotation on: " + method.toString());
+        }
 
-  private static <T> RestfulClientInvoker createClientInvoker(Class<T> clazz, Method method, ResteasyWebTarget base,
-      ProxyConfig config){
-    Set<String> httpMethods = IsHttpMethod.getHttpMethods(method);
-    if(httpMethods == null || httpMethods.size() != 1){
-      throw new RuntimeException("You must use at least one, but no more than one http method annotation on: " + method.toString());
+        RestfulClientInvoker invoker = new RestfulClientInvoker(base, clazz, method, config);
+        invoker.setHttpMethod(httpMethods.iterator().next());
+        return invoker;
     }
 
-    RestfulClientInvoker invoker = new RestfulClientInvoker(base, clazz, method, config);
-    invoker.setHttpMethod(httpMethods.iterator().next());
-    return invoker;
-  }
+    private RestfulProxyBuilder(Class<T> iface, ResteasyWebTarget webTarget) {
+        this.iface = iface;
+        this.webTarget = webTarget;
+    }
 
-  private RestfulProxyBuilder(Class<T> iface, ResteasyWebTarget webTarget){
-    this.iface = iface;
-    this.webTarget = webTarget;
-  }
+    public RestfulProxyBuilder<T> classloader(ClassLoader cl) {
+        this.loader = cl;
+        return this;
+    }
 
-  public RestfulProxyBuilder<T> classloader(ClassLoader cl){
-    this.loader = cl;
-    return this;
-  }
+    public RestfulProxyBuilder<T> defaultProduces(MediaType type) {
+        this.serverProduces = type;
+        return this;
+    }
 
-  public RestfulProxyBuilder<T> defaultProduces(MediaType type){
-    this.serverProduces = type;
-    return this;
-  }
+    public RestfulProxyBuilder<T> defaultConsumes(MediaType type) {
+        this.serverConsumes = type;
+        return this;
+    }
 
-  public RestfulProxyBuilder<T> defaultConsumes(MediaType type){
-    this.serverConsumes = type;
-    return this;
-  }
+    public RestfulProxyBuilder<T> defaultProduces(String type) {
+        this.serverProduces = MediaType.valueOf(type);
+        return this;
+    }
 
-  public RestfulProxyBuilder<T> defaultProduces(String type){
-    this.serverProduces = MediaType.valueOf(type);
-    return this;
-  }
+    public RestfulProxyBuilder<T> defaultConsumes(String type) {
+        this.serverConsumes = MediaType.valueOf(type);
+        return this;
+    }
 
-  public RestfulProxyBuilder<T> defaultConsumes(String type){
-    this.serverConsumes = MediaType.valueOf(type);
-    return this;
-  }
-
-  public Map<Method, RestfulClientInvoker> build(){
-    return proxy(iface, webTarget, new ProxyConfig(loader, serverConsumes, serverProduces));
-  }
+    public Map<Method, RestfulClientInvoker> build() {
+        return proxy(iface, webTarget, new ProxyConfig(loader, serverConsumes, serverProduces));
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/RestfulServletContainerListener.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/RestfulServletContainerListener.java
@@ -27,22 +27,22 @@ import com.weibo.api.motan.protocol.restful.support.RpcExceptionMapper;
 
 public class RestfulServletContainerListener extends ResteasyBootstrap implements ServletContextListener {
 
-	@Override
-	public void contextInitialized(ServletContextEvent sce) {
-		ServletContext servletContext = sce.getServletContext();
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        ServletContext servletContext = sce.getServletContext();
 
-		servletContext.setInitParameter("resteasy.injector.factory", RestfulInjectorFactory.class.getName());
-		servletContext.setInitParameter(ResteasyContextParameters.RESTEASY_PROVIDERS,
-				RpcExceptionMapper.class.getName());
+        servletContext.setInitParameter("resteasy.injector.factory", RestfulInjectorFactory.class.getName());
+        servletContext.setInitParameter(ResteasyContextParameters.RESTEASY_PROVIDERS,
+                RpcExceptionMapper.class.getName());
 
-		super.contextInitialized(sce);
+        super.contextInitialized(sce);
 
-		ServletRestServer.setResteasyDeployment(deployment);
-	}
+        ServletRestServer.setResteasyDeployment(deployment);
+    }
 
-	@Override
-	public void contextDestroyed(ServletContextEvent sce) {
-		super.contextDestroyed(sce);
-	}
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+        super.contextDestroyed(sce);
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/RestfulServletContainerListener.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/RestfulServletContainerListener.java
@@ -19,12 +19,13 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+import org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap;
 import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 
 import com.weibo.api.motan.protocol.restful.support.RestfulInjectorFactory;
 import com.weibo.api.motan.protocol.restful.support.RpcExceptionMapper;
 
-public class RestfulServletContainerListener implements ServletContextListener {
+public class RestfulServletContainerListener extends ResteasyBootstrap implements ServletContextListener {
 
 	@Override
 	public void contextInitialized(ServletContextEvent sce) {
@@ -34,12 +35,14 @@ public class RestfulServletContainerListener implements ServletContextListener {
 		servletContext.setInitParameter(ResteasyContextParameters.RESTEASY_PROVIDERS,
 				RpcExceptionMapper.class.getName());
 
-		ServletRestServer.setServletContext(sce.getServletContext());
+		super.contextInitialized(sce);
+
+		ServletRestServer.setResteasyDeployment(deployment);
 	}
 
 	@Override
 	public void contextDestroyed(ServletContextEvent sce) {
-
+		super.contextDestroyed(sce);
 	}
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/RestfulServletContainerListener.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/RestfulServletContainerListener.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful.support.servlet;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
+
+import com.weibo.api.motan.protocol.restful.support.RestfulInjectorFactory;
+import com.weibo.api.motan.protocol.restful.support.RpcExceptionMapper;
+
+public class RestfulServletContainerListener implements ServletContextListener {
+
+	@Override
+	public void contextInitialized(ServletContextEvent sce) {
+		ServletContext servletContext = sce.getServletContext();
+
+		servletContext.setInitParameter("resteasy.injector.factory", RestfulInjectorFactory.class.getName());
+		servletContext.setInitParameter(ResteasyContextParameters.RESTEASY_PROVIDERS,
+				RpcExceptionMapper.class.getName());
+
+		ServletRestServer.setServletContext(sce.getServletContext());
+	}
+
+	@Override
+	public void contextDestroyed(ServletContextEvent sce) {
+
+	}
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/ServletEndpointFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/ServletEndpointFactory.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful.support.servlet;
+
+import com.weibo.api.motan.core.extension.SpiMeta;
+import com.weibo.api.motan.protocol.restful.RestServer;
+import com.weibo.api.motan.protocol.restful.support.AbstractEndpointFactory;
+import com.weibo.api.motan.rpc.URL;
+
+@SpiMeta(name = "servlet")
+public class ServletEndpointFactory extends AbstractEndpointFactory{
+
+  @Override
+  protected RestServer innerCreateServer(URL url){
+    ServletRestServer server = new ServletRestServer();
+    server.checkEnv();
+    return server;
+  }
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/ServletEndpointFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/ServletEndpointFactory.java
@@ -23,11 +23,11 @@ import com.weibo.api.motan.rpc.URL;
 @SpiMeta(name = "servlet")
 public class ServletEndpointFactory extends AbstractEndpointFactory {
 
-	@Override
-	protected RestServer innerCreateServer(URL url) {
-		ServletRestServer server = new ServletRestServer();
-		server.checkEnv();
-		return server;
-	}
+    @Override
+    protected RestServer innerCreateServer(URL url) {
+        ServletRestServer server = new ServletRestServer();
+        server.checkEnv();
+        return server;
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/ServletEndpointFactory.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/ServletEndpointFactory.java
@@ -21,13 +21,13 @@ import com.weibo.api.motan.protocol.restful.support.AbstractEndpointFactory;
 import com.weibo.api.motan.rpc.URL;
 
 @SpiMeta(name = "servlet")
-public class ServletEndpointFactory extends AbstractEndpointFactory{
+public class ServletEndpointFactory extends AbstractEndpointFactory {
 
-  @Override
-  protected RestServer innerCreateServer(URL url){
-    ServletRestServer server = new ServletRestServer();
-    server.checkEnv();
-    return server;
-  }
+	@Override
+	protected RestServer innerCreateServer(URL url) {
+		ServletRestServer server = new ServletRestServer();
+		server.checkEnv();
+		return server;
+	}
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/ServletRestServer.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/ServletRestServer.java
@@ -15,34 +15,22 @@
  */
 package com.weibo.api.motan.protocol.restful.support.servlet;
 
-import java.util.Map;
-
-import javax.servlet.ServletContext;
-
-import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
-import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
 import org.jboss.resteasy.spi.ResteasyDeployment;
 
 import com.weibo.api.motan.exception.MotanFrameworkException;
 import com.weibo.api.motan.protocol.restful.RestServer;
 
-@SuppressWarnings("unchecked")
 public class ServletRestServer implements RestServer {
-	private static ServletContext servletContext;
+	private static ResteasyDeployment deployment;
 
-	public static void setServletContext(ServletContext servletContext) {
-		ServletRestServer.servletContext = servletContext;
+	public static void setResteasyDeployment(ResteasyDeployment deployment) {
+		ServletRestServer.deployment = deployment;
 	}
 
 	public void checkEnv() {
-		if (servletContext == null) {
+		if (deployment == null) {
 			throw new MotanFrameworkException("please config <listener-class>"
 					+ RestfulServletContainerListener.class.getName() + "</listener-class> in your web.xml file");
-		}
-
-		if (getDeployment() == null) {
-			throw new MotanFrameworkException("please config <servlet>" + HttpServletDispatcher.class.getName()
-					+ "</servlet> and <load-on-start>1</load-on-start> in your web.xml file");
 		}
 	}
 
@@ -52,17 +40,6 @@ public class ServletRestServer implements RestServer {
 
 	@Override
 	public ResteasyDeployment getDeployment() {
-		ResteasyDeployment deployment = (ResteasyDeployment) servletContext
-				.getAttribute(ResteasyDeployment.class.getName());
-		if (deployment == null) {
-			// 在ListenerBootstrap中创建，key为servletMappingPrefix
-			Map<String, ResteasyDeployment> deployments = (Map<String, ResteasyDeployment>) servletContext
-					.getAttribute(ResteasyContextParameters.RESTEASY_DEPLOYMENTS);
-			if (deployments != null && !deployments.isEmpty()) {
-				deployment = deployments.values().iterator().next();
-			}
-		}
-
 		return deployment;
 	}
 

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/ServletRestServer.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/ServletRestServer.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful.support.servlet;
+
+import java.util.Map;
+
+import javax.servlet.ServletContext;
+
+import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
+import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
+import org.jboss.resteasy.spi.ResteasyDeployment;
+
+import com.weibo.api.motan.exception.MotanFrameworkException;
+import com.weibo.api.motan.protocol.restful.RestServer;
+
+@SuppressWarnings("unchecked")
+public class ServletRestServer implements RestServer {
+	private static ServletContext servletContext;
+
+	public static void setServletContext(ServletContext servletContext) {
+		ServletRestServer.servletContext = servletContext;
+	}
+
+	public void checkEnv() {
+		if (servletContext == null) {
+			throw new MotanFrameworkException("please config <listener-class>"
+					+ RestfulServletContainerListener.class.getName() + "</listener-class> in your web.xml file");
+		}
+
+		if (getDeployment() == null) {
+			throw new MotanFrameworkException("please config <servlet>" + HttpServletDispatcher.class.getName()
+					+ "</servlet> and <load-on-start>1</load-on-start> in your web.xml file");
+		}
+	}
+
+	@Override
+	public void start() {
+	}
+
+	@Override
+	public ResteasyDeployment getDeployment() {
+		ResteasyDeployment deployment = (ResteasyDeployment) servletContext
+				.getAttribute(ResteasyDeployment.class.getName());
+		if (deployment == null) {
+			// 在ListenerBootstrap中创建，key为servletMappingPrefix
+			Map<String, ResteasyDeployment> deployments = (Map<String, ResteasyDeployment>) servletContext
+					.getAttribute(ResteasyContextParameters.RESTEASY_DEPLOYMENTS);
+			if (deployments != null && !deployments.isEmpty()) {
+				deployment = deployments.values().iterator().next();
+			}
+		}
+
+		return deployment;
+	}
+
+	@Override
+	public void stop() {
+	}
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/ServletRestServer.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/java/com/weibo/api/motan/protocol/restful/support/servlet/ServletRestServer.java
@@ -21,30 +21,30 @@ import com.weibo.api.motan.exception.MotanFrameworkException;
 import com.weibo.api.motan.protocol.restful.RestServer;
 
 public class ServletRestServer implements RestServer {
-	private static ResteasyDeployment deployment;
+    private static ResteasyDeployment deployment;
 
-	public static void setResteasyDeployment(ResteasyDeployment deployment) {
-		ServletRestServer.deployment = deployment;
-	}
+    public static void setResteasyDeployment(ResteasyDeployment deployment) {
+        ServletRestServer.deployment = deployment;
+    }
 
-	public void checkEnv() {
-		if (deployment == null) {
-			throw new MotanFrameworkException("please config <listener-class>"
-					+ RestfulServletContainerListener.class.getName() + "</listener-class> in your web.xml file");
-		}
-	}
+    public void checkEnv() {
+        if (deployment == null) {
+            throw new MotanFrameworkException("please config <listener-class>"
+                    + RestfulServletContainerListener.class.getName() + "</listener-class> in your web.xml file");
+        }
+    }
 
-	@Override
-	public void start() {
-	}
+    @Override
+    public void start() {
+    }
 
-	@Override
-	public ResteasyDeployment getDeployment() {
-		return deployment;
-	}
+    @Override
+    public ResteasyDeployment getDeployment() {
+        return deployment;
+    }
 
-	@Override
-	public void stop() {
-	}
+    @Override
+    public void stop() {
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/resources/META-INF/services/com.weibo.api.motan.protocol.restful.EndpointFactory
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/resources/META-INF/services/com.weibo.api.motan.protocol.restful.EndpointFactory
@@ -1,0 +1,18 @@
+#
+#  Copyright 2009-2016 Weibo, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+com.weibo.api.motan.protocol.restful.support.netty.NettyEndpointFactory
+com.weibo.api.motan.protocol.restful.support.servlet.ServletEndpointFactory

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/main/resources/META-INF/services/com.weibo.api.motan.rpc.Protocol
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/main/resources/META-INF/services/com.weibo.api.motan.rpc.Protocol
@@ -1,0 +1,17 @@
+#
+#  Copyright 2009-2016 Weibo, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+com.weibo.api.motan.protocol.restful.RestfulProtocol

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/ClientFilter.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/ClientFilter.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful;
+
+import com.weibo.api.motan.core.extension.SpiMeta;
+import com.weibo.api.motan.filter.Filter;
+import com.weibo.api.motan.protocol.restful.support.RestfulClientResponse;
+import com.weibo.api.motan.rpc.Caller;
+import com.weibo.api.motan.rpc.Request;
+import com.weibo.api.motan.rpc.Response;
+
+@SpiMeta(name = "clientf")
+public class ClientFilter implements Filter{
+
+  @Override
+  public Response filter(Caller<?> caller, Request request){
+    // pass attachment
+    request.setAttachment("testName", "testName");
+
+    Response response = caller.call(request);
+
+    assert response instanceof RestfulClientResponse;
+
+    RestfulClientResponse rfr = (RestfulClientResponse) response;
+    // obtain httpResponse 、 responseStatus、responseHeader and so on
+    rfr.getHttpResponse();
+
+    return response;
+  }
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/ClientFilter.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/ClientFilter.java
@@ -23,22 +23,22 @@ import com.weibo.api.motan.rpc.Request;
 import com.weibo.api.motan.rpc.Response;
 
 @SpiMeta(name = "clientf")
-public class ClientFilter implements Filter{
+public class ClientFilter implements Filter {
 
-  @Override
-  public Response filter(Caller<?> caller, Request request){
-    // pass attachment
-    request.setAttachment("testName", "testName");
+    @Override
+    public Response filter(Caller<?> caller, Request request) {
+        // pass attachment
+        request.setAttachment("testName", "testName");
 
-    Response response = caller.call(request);
+        Response response = caller.call(request);
 
-    assert response instanceof RestfulClientResponse;
+        assert response instanceof RestfulClientResponse;
 
-    RestfulClientResponse rfr = (RestfulClientResponse) response;
-    // obtain httpResponse 、 responseStatus、responseHeader and so on
-    rfr.getHttpResponse();
+        RestfulClientResponse rfr = (RestfulClientResponse) response;
+        // obtain httpResponse 、 responseStatus、responseHeader and so on
+        rfr.getHttpResponse();
 
-    return response;
-  }
+        return response;
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/HelloResource.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/HelloResource.java
@@ -28,46 +28,46 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 @Path("/rest")
-public interface HelloResource{
+public interface HelloResource {
 
-  @GET
-  @Produces(MediaType.APPLICATION_JSON)
-  List<User> hello(@CookieParam("uid") int uid);
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    List<User> hello(@CookieParam("uid") int uid);
 
-  @GET
-  @Path("/primitive")
-  @Produces(MediaType.TEXT_PLAIN)
-  String testPrimitiveType();
+    @GET
+    @Path("/primitive")
+    @Produces(MediaType.TEXT_PLAIN)
+    String testPrimitiveType();
 
-  @POST
-  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-  @Produces(MediaType.APPLICATION_JSON)
-  Response add(@FormParam("id") int id, @FormParam("name") String name);
+    @POST
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.APPLICATION_JSON)
+    Response add(@FormParam("id") int id, @FormParam("name") String name);
 
-  @GET
-  @Path("/exception")
-  @Produces(MediaType.APPLICATION_JSON)
-  void testException();
+    @GET
+    @Path("/exception")
+    @Produces(MediaType.APPLICATION_JSON)
+    void testException();
 
-  public static class User{
-    private int id;
-    private String name;
+    public static class User {
+        private int id;
+        private String name;
 
-    public User(){
+        public User() {
+        }
+
+        public User(int id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
     }
-
-    public User(int id, String name){
-      this.id = id;
-      this.name = name;
-    }
-
-    public int getId(){
-      return id;
-    }
-
-    public String getName(){
-      return name;
-    }
-  }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/HelloResource.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/HelloResource.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful;
+
+import java.util.List;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Path("/rest")
+public interface HelloResource{
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  List<User> hello(@CookieParam("uid") int uid);
+
+  @GET
+  @Path("/primitive")
+  @Produces(MediaType.TEXT_PLAIN)
+  String testPrimitiveType();
+
+  @POST
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+  @Produces(MediaType.APPLICATION_JSON)
+  Response add(@FormParam("id") int id, @FormParam("name") String name);
+
+  @GET
+  @Path("/exception")
+  @Produces(MediaType.APPLICATION_JSON)
+  void testException();
+
+  public static class User{
+    private int id;
+    private String name;
+
+    public User(){
+    }
+
+    public User(int id, String name){
+      this.id = id;
+      this.name = name;
+    }
+
+    public int getId(){
+      return id;
+    }
+
+    public String getName(){
+      return name;
+    }
+  }
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/RestHelloResource.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/RestHelloResource.java
@@ -21,25 +21,25 @@ import java.util.List;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 
-public class RestHelloResource implements HelloResource{
+public class RestHelloResource implements HelloResource {
 
-  public List<User> hello(int id){
-    return Arrays.asList(new User(id, "de"));
-  }
+    public List<User> hello(int id) {
+        return Arrays.asList(new User(id, "de"));
+    }
 
-  @Override
-  public String testPrimitiveType(){
-    return "helloworld";
-  }
+    @Override
+    public String testPrimitiveType() {
+        return "helloworld";
+    }
 
-  @Override
-  public Response add(int id, String name){
-    return Response.ok().cookie(new NewCookie("ck", String.valueOf(id))).entity(new User(id, name)).build();
-  }
+    @Override
+    public Response add(int id, String name) {
+        return Response.ok().cookie(new NewCookie("ck", String.valueOf(id))).entity(new User(id, name)).build();
+    }
 
-  @Override
-  public void testException(){
-    throw new UnsupportedOperationException("unsupport");
-  }
+    @Override
+    public void testException() {
+        throw new UnsupportedOperationException("unsupport");
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/RestHelloResource.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/RestHelloResource.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.ws.rs.core.NewCookie;
+import javax.ws.rs.core.Response;
+
+public class RestHelloResource implements HelloResource{
+
+  public List<User> hello(int id){
+    return Arrays.asList(new User(id, "de"));
+  }
+
+  @Override
+  public String testPrimitiveType(){
+    return "helloworld";
+  }
+
+  @Override
+  public Response add(int id, String name){
+    return Response.ok().cookie(new NewCookie("ck", String.valueOf(id))).entity(new User(id, name)).build();
+  }
+
+  @Override
+  public void testException(){
+    throw new UnsupportedOperationException("unsupport");
+  }
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/ServerFilter.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/ServerFilter.java
@@ -24,27 +24,27 @@ import com.weibo.api.motan.rpc.Request;
 import com.weibo.api.motan.rpc.Response;
 
 @SpiMeta(name = "serverf")
-public class ServerFilter implements Filter{
+public class ServerFilter implements Filter {
 
-  @Override
-  public Response filter(Caller<?> caller, Request request){
-    assert request instanceof RestfulContainerRequest;
+    @Override
+    public Response filter(Caller<?> caller, Request request) {
+        assert request instanceof RestfulContainerRequest;
 
-    RestfulContainerRequest req = (RestfulContainerRequest) request;
-    if(!"testName".equals(req.getAttachments().get("testName"))){
-      DefaultResponse resp = new DefaultResponse(request.getRequestId());
-      resp.setException(new IllegalStateException("must contain testName attachment"));
-      return resp;
+        RestfulContainerRequest req = (RestfulContainerRequest) request;
+        if (!"testName".equals(req.getAttachments().get("testName"))) {
+            DefaultResponse resp = new DefaultResponse(request.getRequestId());
+            resp.setException(new IllegalStateException("must contain testName attachment"));
+            return resp;
+        }
+
+        assert request.getInterfaceName() != null;
+        assert request.getMethodName() != null;
+        assert request.getParamtersDesc() != null;
+
+        // obtain httpRequest、 requestUri、httpMethod and so on
+        req.getHttpRequest();
+
+        return caller.call(request);
     }
-
-    assert request.getInterfaceName() != null;
-    assert request.getMethodName() != null;
-    assert request.getParamtersDesc() != null;
-
-    // obtain httpRequest、 requestUri、httpMethod and so on
-    req.getHttpRequest();
-
-    return caller.call(request);
-  }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/ServerFilter.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/ServerFilter.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful;
+
+import com.weibo.api.motan.core.extension.SpiMeta;
+import com.weibo.api.motan.filter.Filter;
+import com.weibo.api.motan.protocol.restful.support.RestfulContainerRequest;
+import com.weibo.api.motan.rpc.Caller;
+import com.weibo.api.motan.rpc.DefaultResponse;
+import com.weibo.api.motan.rpc.Request;
+import com.weibo.api.motan.rpc.Response;
+
+@SpiMeta(name = "serverf")
+public class ServerFilter implements Filter{
+
+  @Override
+  public Response filter(Caller<?> caller, Request request){
+    assert request instanceof RestfulContainerRequest;
+
+    RestfulContainerRequest req = (RestfulContainerRequest) request;
+    if(!"testName".equals(req.getAttachments().get("testName"))){
+      DefaultResponse resp = new DefaultResponse(request.getRequestId());
+      resp.setException(new IllegalStateException("must contain testName attachment"));
+      return resp;
+    }
+
+    assert request.getInterfaceName() != null;
+    assert request.getMethodName() != null;
+    assert request.getParamtersDesc() != null;
+
+    // obtain httpRequest、 requestUri、httpMethod and so on
+    req.getHttpRequest();
+
+    return caller.call(request);
+  }
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/TestRestful.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/TestRestful.java
@@ -1,0 +1,113 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful;
+
+import java.util.List;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.weibo.api.motan.config.ProtocolConfig;
+import com.weibo.api.motan.config.RefererConfig;
+import com.weibo.api.motan.config.RegistryConfig;
+import com.weibo.api.motan.config.ServiceConfig;
+import com.weibo.api.motan.protocol.restful.HelloResource.User;
+
+public class TestRestful {
+	private ServiceConfig<HelloResource> serviceConfig;
+	private RefererConfig<HelloResource> refererConfig;
+	private HelloResource resource;
+
+	@Before
+	public void setUp() {
+		ProtocolConfig protocolConfig = new ProtocolConfig();
+		protocolConfig.setId("testRpc");
+		protocolConfig.setName("restful");
+		protocolConfig.setEndpointFactory("netty");
+
+		RegistryConfig registryConfig = new RegistryConfig();
+		registryConfig.setName("local");
+		registryConfig.setAddress("127.0.0.1");
+		registryConfig.setPort(0);
+
+		serviceConfig = new ServiceConfig<HelloResource>();
+		serviceConfig.setRef(new RestHelloResource());
+		serviceConfig.setInterface(HelloResource.class);
+		serviceConfig.setProtocol(protocolConfig);
+		serviceConfig.setExport("testRpc:8002");
+		serviceConfig.setFilter("serverf");
+		serviceConfig.setGroup("test-group");
+		serviceConfig.setVersion("0.0.3");
+		serviceConfig.setRegistry(registryConfig);
+
+		serviceConfig.export();
+
+		refererConfig = new RefererConfig<HelloResource>();
+		refererConfig.setDirectUrl("127.0.0.1:8002");
+		refererConfig.setGroup("test-group");
+		refererConfig.setVersion("0.0.3");
+		refererConfig.setFilter("clientf");
+		refererConfig.setProtocol(protocolConfig);
+		refererConfig.setInterface(HelloResource.class);
+
+		resource = refererConfig.getRef();
+	}
+
+	@Test
+	public void testPrimitiveType() {
+		Assert.assertEquals("helloworld", resource.testPrimitiveType());
+	}
+
+	@Test
+	public void testCookie() {
+		List<User> users = resource.hello(23);
+		Assert.assertEquals(users.size(), 1);
+		Assert.assertEquals(users.get(0).getId(), 23);
+		Assert.assertEquals(users.get(0).getName(), "de");
+	}
+
+	@Test
+	public void testReturnResponse() {
+		Response resp = resource.add(2, "de");
+		Assert.assertEquals(resp.getStatus(), Status.OK.getStatusCode());
+		Assert.assertEquals(resp.getCookies().size(), 1);
+		Assert.assertEquals(resp.getCookies().get("ck").getName(), "ck");
+		Assert.assertEquals(resp.getCookies().get("ck").getValue(), "2");
+
+		User user = resp.readEntity(User.class);
+		resp.close();
+
+		Assert.assertEquals(user.getId(), 2);
+		Assert.assertEquals(user.getName(), "de");
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testException() {
+		resource.testException();
+	}
+
+	@After
+	public void tearDown() {
+		refererConfig.destroy();
+		serviceConfig.unexport();
+	}
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/TestRestful.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/TestRestful.java
@@ -32,82 +32,82 @@ import com.weibo.api.motan.config.ServiceConfig;
 import com.weibo.api.motan.protocol.restful.HelloResource.User;
 
 public class TestRestful {
-	private ServiceConfig<HelloResource> serviceConfig;
-	private RefererConfig<HelloResource> refererConfig;
-	private HelloResource resource;
+    private ServiceConfig<HelloResource> serviceConfig;
+    private RefererConfig<HelloResource> refererConfig;
+    private HelloResource resource;
 
-	@Before
-	public void setUp() {
-		ProtocolConfig protocolConfig = new ProtocolConfig();
-		protocolConfig.setId("testRpc");
-		protocolConfig.setName("restful");
-		protocolConfig.setEndpointFactory("netty");
+    @Before
+    public void setUp() {
+        ProtocolConfig protocolConfig = new ProtocolConfig();
+        protocolConfig.setId("testRpc");
+        protocolConfig.setName("restful");
+        protocolConfig.setEndpointFactory("netty");
 
-		RegistryConfig registryConfig = new RegistryConfig();
-		registryConfig.setName("local");
-		registryConfig.setAddress("127.0.0.1");
-		registryConfig.setPort(0);
+        RegistryConfig registryConfig = new RegistryConfig();
+        registryConfig.setName("local");
+        registryConfig.setAddress("127.0.0.1");
+        registryConfig.setPort(0);
 
-		serviceConfig = new ServiceConfig<HelloResource>();
-		serviceConfig.setRef(new RestHelloResource());
-		serviceConfig.setInterface(HelloResource.class);
-		serviceConfig.setProtocol(protocolConfig);
-		serviceConfig.setExport("testRpc:8002");
-		serviceConfig.setFilter("serverf");
-		serviceConfig.setGroup("test-group");
-		serviceConfig.setVersion("0.0.3");
-		serviceConfig.setRegistry(registryConfig);
+        serviceConfig = new ServiceConfig<HelloResource>();
+        serviceConfig.setRef(new RestHelloResource());
+        serviceConfig.setInterface(HelloResource.class);
+        serviceConfig.setProtocol(protocolConfig);
+        serviceConfig.setExport("testRpc:8002");
+        serviceConfig.setFilter("serverf");
+        serviceConfig.setGroup("test-group");
+        serviceConfig.setVersion("0.0.3");
+        serviceConfig.setRegistry(registryConfig);
 
-		serviceConfig.export();
+        serviceConfig.export();
 
-		refererConfig = new RefererConfig<HelloResource>();
-		refererConfig.setDirectUrl("127.0.0.1:8002");
-		refererConfig.setGroup("test-group");
-		refererConfig.setVersion("0.0.3");
-		refererConfig.setFilter("clientf");
-		refererConfig.setProtocol(protocolConfig);
-		refererConfig.setInterface(HelloResource.class);
+        refererConfig = new RefererConfig<HelloResource>();
+        refererConfig.setDirectUrl("127.0.0.1:8002");
+        refererConfig.setGroup("test-group");
+        refererConfig.setVersion("0.0.3");
+        refererConfig.setFilter("clientf");
+        refererConfig.setProtocol(protocolConfig);
+        refererConfig.setInterface(HelloResource.class);
 
-		resource = refererConfig.getRef();
-	}
+        resource = refererConfig.getRef();
+    }
 
-	@Test
-	public void testPrimitiveType() {
-		Assert.assertEquals("helloworld", resource.testPrimitiveType());
-	}
+    @Test
+    public void testPrimitiveType() {
+        Assert.assertEquals("helloworld", resource.testPrimitiveType());
+    }
 
-	@Test
-	public void testCookie() {
-		List<User> users = resource.hello(23);
-		Assert.assertEquals(users.size(), 1);
-		Assert.assertEquals(users.get(0).getId(), 23);
-		Assert.assertEquals(users.get(0).getName(), "de");
-	}
+    @Test
+    public void testCookie() {
+        List<User> users = resource.hello(23);
+        Assert.assertEquals(users.size(), 1);
+        Assert.assertEquals(users.get(0).getId(), 23);
+        Assert.assertEquals(users.get(0).getName(), "de");
+    }
 
-	@Test
-	public void testReturnResponse() {
-		Response resp = resource.add(2, "de");
-		Assert.assertEquals(resp.getStatus(), Status.OK.getStatusCode());
-		Assert.assertEquals(resp.getCookies().size(), 1);
-		Assert.assertEquals(resp.getCookies().get("ck").getName(), "ck");
-		Assert.assertEquals(resp.getCookies().get("ck").getValue(), "2");
+    @Test
+    public void testReturnResponse() {
+        Response resp = resource.add(2, "de");
+        Assert.assertEquals(resp.getStatus(), Status.OK.getStatusCode());
+        Assert.assertEquals(resp.getCookies().size(), 1);
+        Assert.assertEquals(resp.getCookies().get("ck").getName(), "ck");
+        Assert.assertEquals(resp.getCookies().get("ck").getValue(), "2");
 
-		User user = resp.readEntity(User.class);
-		resp.close();
+        User user = resp.readEntity(User.class);
+        resp.close();
 
-		Assert.assertEquals(user.getId(), 2);
-		Assert.assertEquals(user.getName(), "de");
-	}
+        Assert.assertEquals(user.getId(), 2);
+        Assert.assertEquals(user.getName(), "de");
+    }
 
-	@Test(expected = UnsupportedOperationException.class)
-	public void testException() {
-		resource.testException();
-	}
+    @Test(expected = UnsupportedOperationException.class)
+    public void testException() {
+        resource.testException();
+    }
 
-	@After
-	public void tearDown() {
-		refererConfig.destroy();
-		serviceConfig.unexport();
-	}
+    @After
+    public void tearDown() {
+        refererConfig.destroy();
+        serviceConfig.unexport();
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/TestServletCotainerRestful.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/TestServletCotainerRestful.java
@@ -47,140 +47,140 @@ import com.weibo.api.motan.protocol.restful.support.servlet.RestfulServletContai
  *
  */
 public class TestServletCotainerRestful {
-	private Tomcat tomcat;
+    private Tomcat tomcat;
 
-	private ServiceConfig<HelloResource> serviceConfig;
-	private RefererConfig<HelloResource> refererConfig;
-	private HelloResource resource;
+    private ServiceConfig<HelloResource> serviceConfig;
+    private RefererConfig<HelloResource> refererConfig;
+    private HelloResource resource;
 
-	@Before
-	public void setUp() throws Exception {
-		tomcat = new Tomcat();
-		String baseDir = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
-		tomcat.setBaseDir(baseDir);
-		tomcat.setPort(8002);
+    @Before
+    public void setUp() throws Exception {
+        tomcat = new Tomcat();
+        String baseDir = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
+        tomcat.setBaseDir(baseDir);
+        tomcat.setPort(8002);
 
-		tomcat.getConnector().setProperty("URIEncoding", "UTF-8");
-		tomcat.getConnector().setProperty("socket.soReuseAddress", "true");
-		tomcat.getConnector().setProperty("connectionTimeout", "20000");
+        tomcat.getConnector().setProperty("URIEncoding", "UTF-8");
+        tomcat.getConnector().setProperty("socket.soReuseAddress", "true");
+        tomcat.getConnector().setProperty("connectionTimeout", "20000");
 
-		String contextpath = "/cp";
+        String contextpath = "/cp";
 
-		String servletPrefix = "/servlet";
+        String servletPrefix = "/servlet";
 
-		/**
-		 * <pre>
-		 *
-		 * <servlet>
-		 *  <servlet-name>dispatcher</servlet-name>
-		 *  <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
-		 *  <load-on-startup>1</load-on-startup>
-		 *  <init-param>
-		 *    <param-name>resteasy.servlet.mapping.prefix</param-name>
-		 *    <param-value>/servlet</param-value>  <!-- 此处实际为servlet-mapping的url-pattern，具体配置见resteasy文档-->
-		 *  </init-param>
-		 * </servlet>
-		 *
-		 * <servlet-mapping>
-		 *   <servlet-name>dispatcher</servlet-name>
-		 *   <url-pattern>/servlet/*</url-pattern>
-		 * </servlet-mapping>
-		 *
-		 * </pre>
-		 */
-		Context context = tomcat.addContext(contextpath, baseDir);
-		Wrapper wrapper = Tomcat.addServlet(context, "dispatcher", HttpServletDispatcher.class.getName());
-		wrapper.addInitParameter(ResteasyContextParameters.RESTEASY_SERVLET_MAPPING_PREFIX, servletPrefix);
-		wrapper.setLoadOnStartup(1);
-		context.addServletMapping(servletPrefix + "/*", "dispatcher");
+        /**
+         * <pre>
+         *
+         * <servlet>
+         *  <servlet-name>dispatcher</servlet-name>
+         *  <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
+         *  <load-on-startup>1</load-on-startup>
+         *  <init-param>
+         *    <param-name>resteasy.servlet.mapping.prefix</param-name>
+         *    <param-value>/servlet</param-value>  <!-- 此处实际为servlet-mapping的url-pattern，具体配置见resteasy文档-->
+         *  </init-param>
+         * </servlet>
+         *
+         * <servlet-mapping>
+         *   <servlet-name>dispatcher</servlet-name>
+         *   <url-pattern>/servlet/*</url-pattern>
+         * </servlet-mapping>
+         *
+         * </pre>
+         */
+        Context context = tomcat.addContext(contextpath, baseDir);
+        Wrapper wrapper = Tomcat.addServlet(context, "dispatcher", HttpServletDispatcher.class.getName());
+        wrapper.addInitParameter(ResteasyContextParameters.RESTEASY_SERVLET_MAPPING_PREFIX, servletPrefix);
+        wrapper.setLoadOnStartup(1);
+        context.addServletMapping(servletPrefix + "/*", "dispatcher");
 
-		/**
-		 * <listener>
-		 * <listener-class>com.weibo.api.motan.protocol.restful.support.servlet.RestfulServletContainerListener</listener-class>
-		 * </listener>
-		 */
-		context.addApplicationListener(RestfulServletContainerListener.class.getName());
+        /**
+         * <listener>
+         * <listener-class>com.weibo.api.motan.protocol.restful.support.servlet.RestfulServletContainerListener</listener-class>
+         * </listener>
+         */
+        context.addApplicationListener(RestfulServletContainerListener.class.getName());
 
-		tomcat.start();
+        tomcat.start();
 
-		ProtocolConfig protocolConfig = new ProtocolConfig();
-		protocolConfig.setId("testRpc");
-		protocolConfig.setName("restful");
-		protocolConfig.setEndpointFactory("servlet");
+        ProtocolConfig protocolConfig = new ProtocolConfig();
+        protocolConfig.setId("testRpc");
+        protocolConfig.setName("restful");
+        protocolConfig.setEndpointFactory("servlet");
 
-		Map<String, String> ext = new HashMap<String, String>();
-		ext.put("contextpath", contextpath + servletPrefix);
-		protocolConfig.setParameters(ext);
+        Map<String, String> ext = new HashMap<String, String>();
+        ext.put("contextpath", contextpath + servletPrefix);
+        protocolConfig.setParameters(ext);
 
-		RegistryConfig registryConfig = new RegistryConfig();
-		registryConfig.setName("local");
-		registryConfig.setAddress("127.0.0.1");
-		registryConfig.setPort(0);
+        RegistryConfig registryConfig = new RegistryConfig();
+        registryConfig.setName("local");
+        registryConfig.setAddress("127.0.0.1");
+        registryConfig.setPort(0);
 
-		serviceConfig = new ServiceConfig<HelloResource>();
-		serviceConfig.setRef(new RestHelloResource());
-		serviceConfig.setInterface(HelloResource.class);
-		serviceConfig.setProtocol(protocolConfig);
-		// 注意此处配置的端口并不会被使用，建议配置servlet服务器端口
-		serviceConfig.setExport("testRpc:8003");
-		serviceConfig.setFilter("serverf");
-		serviceConfig.setGroup("test-group");
-		serviceConfig.setVersion("0.0.3");
-		serviceConfig.setRegistry(registryConfig);
+        serviceConfig = new ServiceConfig<HelloResource>();
+        serviceConfig.setRef(new RestHelloResource());
+        serviceConfig.setInterface(HelloResource.class);
+        serviceConfig.setProtocol(protocolConfig);
+        // 注意此处配置的端口并不会被使用，建议配置servlet服务器端口
+        serviceConfig.setExport("testRpc:8003");
+        serviceConfig.setFilter("serverf");
+        serviceConfig.setGroup("test-group");
+        serviceConfig.setVersion("0.0.3");
+        serviceConfig.setRegistry(registryConfig);
 
-		serviceConfig.export();
+        serviceConfig.export();
 
-		refererConfig = new RefererConfig<HelloResource>();
-		refererConfig.setDirectUrl("127.0.0.1:8002");
-		refererConfig.setGroup("test-group");
-		refererConfig.setVersion("0.0.3");
-		refererConfig.setFilter("clientf");
-		refererConfig.setProtocol(protocolConfig);
-		refererConfig.setInterface(HelloResource.class);
+        refererConfig = new RefererConfig<HelloResource>();
+        refererConfig.setDirectUrl("127.0.0.1:8002");
+        refererConfig.setGroup("test-group");
+        refererConfig.setVersion("0.0.3");
+        refererConfig.setFilter("clientf");
+        refererConfig.setProtocol(protocolConfig);
+        refererConfig.setInterface(HelloResource.class);
 
-		resource = refererConfig.getRef();
-	}
+        resource = refererConfig.getRef();
+    }
 
-	@Test
-	public void testPrimitiveType() {
-		Assert.assertEquals("helloworld", resource.testPrimitiveType());
-	}
+    @Test
+    public void testPrimitiveType() {
+        Assert.assertEquals("helloworld", resource.testPrimitiveType());
+    }
 
-	@Test
-	public void testCookie() {
-		List<User> users = resource.hello(23);
-		Assert.assertEquals(users.size(), 1);
-		Assert.assertEquals(users.get(0).getId(), 23);
-		Assert.assertEquals(users.get(0).getName(), "de");
-	}
+    @Test
+    public void testCookie() {
+        List<User> users = resource.hello(23);
+        Assert.assertEquals(users.size(), 1);
+        Assert.assertEquals(users.get(0).getId(), 23);
+        Assert.assertEquals(users.get(0).getName(), "de");
+    }
 
-	@Test
-	public void testReturnResponse() {
-		Response resp = resource.add(2, "de");
-		Assert.assertEquals(resp.getStatus(), Status.OK.getStatusCode());
-		Assert.assertEquals(resp.getCookies().size(), 1);
-		Assert.assertEquals(resp.getCookies().get("ck").getName(), "ck");
-		Assert.assertEquals(resp.getCookies().get("ck").getValue(), "2");
+    @Test
+    public void testReturnResponse() {
+        Response resp = resource.add(2, "de");
+        Assert.assertEquals(resp.getStatus(), Status.OK.getStatusCode());
+        Assert.assertEquals(resp.getCookies().size(), 1);
+        Assert.assertEquals(resp.getCookies().get("ck").getName(), "ck");
+        Assert.assertEquals(resp.getCookies().get("ck").getValue(), "2");
 
-		User user = resp.readEntity(User.class);
-		resp.close();
+        User user = resp.readEntity(User.class);
+        resp.close();
 
-		Assert.assertEquals(user.getId(), 2);
-		Assert.assertEquals(user.getName(), "de");
-	}
+        Assert.assertEquals(user.getId(), 2);
+        Assert.assertEquals(user.getName(), "de");
+    }
 
-	@Test(expected = UnsupportedOperationException.class)
-	public void testException() {
-		resource.testException();
-	}
+    @Test(expected = UnsupportedOperationException.class)
+    public void testException() {
+        resource.testException();
+    }
 
-	@After
-	public void tearDown() throws Exception {
-		serviceConfig.unexport();
-		refererConfig.destroy();
+    @After
+    public void tearDown() throws Exception {
+        serviceConfig.unexport();
+        refererConfig.destroy();
 
-		tomcat.stop();
-		tomcat.destroy();
-	}
+        tomcat.stop();
+        tomcat.destroy();
+    }
 
 }

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/TestServletCotainerRestful.java
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/java/com/weibo/api/motan/protocol/restful/TestServletCotainerRestful.java
@@ -1,0 +1,186 @@
+/*
+ *  Copyright 2009-2016 Weibo, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package com.weibo.api.motan.protocol.restful;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.Wrapper;
+import org.apache.catalina.startup.Tomcat;
+import org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher;
+import org.jboss.resteasy.plugins.server.servlet.ResteasyContextParameters;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.weibo.api.motan.config.ProtocolConfig;
+import com.weibo.api.motan.config.RefererConfig;
+import com.weibo.api.motan.config.RegistryConfig;
+import com.weibo.api.motan.config.ServiceConfig;
+import com.weibo.api.motan.protocol.restful.HelloResource.User;
+import com.weibo.api.motan.protocol.restful.support.servlet.RestfulServletContainerListener;
+
+/**
+ * servlet容器下restful协议测试
+ *
+ * @author zhouhaocheng
+ *
+ */
+public class TestServletCotainerRestful {
+	private Tomcat tomcat;
+
+	private ServiceConfig<HelloResource> serviceConfig;
+	private RefererConfig<HelloResource> refererConfig;
+	private HelloResource resource;
+
+	@Before
+	public void setUp() throws Exception {
+		tomcat = new Tomcat();
+		String baseDir = new File(System.getProperty("java.io.tmpdir")).getAbsolutePath();
+		tomcat.setBaseDir(baseDir);
+		tomcat.setPort(8002);
+
+		tomcat.getConnector().setProperty("URIEncoding", "UTF-8");
+		tomcat.getConnector().setProperty("socket.soReuseAddress", "true");
+		tomcat.getConnector().setProperty("connectionTimeout", "20000");
+
+		String contextpath = "/cp";
+
+		String servletPrefix = "/servlet";
+
+		/**
+		 * <pre>
+		 *
+		 * <servlet>
+		 *  <servlet-name>dispatcher</servlet-name>
+		 *  <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
+		 *  <load-on-startup>1</load-on-startup>
+		 *  <init-param>
+		 *    <param-name>resteasy.servlet.mapping.prefix</param-name>
+		 *    <param-value>/servlet</param-value>  <!-- 此处实际为servlet-mapping的url-pattern，具体配置见resteasy文档-->
+		 *  </init-param>
+		 * </servlet>
+		 *
+		 * <servlet-mapping>
+		 *   <servlet-name>dispatcher</servlet-name>
+		 *   <url-pattern>/servlet/*</url-pattern>
+		 * </servlet-mapping>
+		 *
+		 * </pre>
+		 */
+		Context context = tomcat.addContext(contextpath, baseDir);
+		Wrapper wrapper = Tomcat.addServlet(context, "dispatcher", HttpServletDispatcher.class.getName());
+		wrapper.addInitParameter(ResteasyContextParameters.RESTEASY_SERVLET_MAPPING_PREFIX, servletPrefix);
+		wrapper.setLoadOnStartup(1);
+		context.addServletMapping(servletPrefix + "/*", "dispatcher");
+
+		/**
+		 * <listener>
+		 * <listener-class>com.weibo.api.motan.protocol.restful.support.servlet.RestfulServletContainerListener</listener-class>
+		 * </listener>
+		 */
+		context.addApplicationListener(RestfulServletContainerListener.class.getName());
+
+		tomcat.start();
+
+		ProtocolConfig protocolConfig = new ProtocolConfig();
+		protocolConfig.setId("testRpc");
+		protocolConfig.setName("restful");
+		protocolConfig.setEndpointFactory("servlet");
+
+		Map<String, String> ext = new HashMap<String, String>();
+		ext.put("contextpath", contextpath + servletPrefix);
+		protocolConfig.setParameters(ext);
+
+		RegistryConfig registryConfig = new RegistryConfig();
+		registryConfig.setName("local");
+		registryConfig.setAddress("127.0.0.1");
+		registryConfig.setPort(0);
+
+		serviceConfig = new ServiceConfig<HelloResource>();
+		serviceConfig.setRef(new RestHelloResource());
+		serviceConfig.setInterface(HelloResource.class);
+		serviceConfig.setProtocol(protocolConfig);
+		// 注意此处配置的端口并不会被使用，建议配置servlet服务器端口
+		serviceConfig.setExport("testRpc:8003");
+		serviceConfig.setFilter("serverf");
+		serviceConfig.setGroup("test-group");
+		serviceConfig.setVersion("0.0.3");
+		serviceConfig.setRegistry(registryConfig);
+
+		serviceConfig.export();
+
+		refererConfig = new RefererConfig<HelloResource>();
+		refererConfig.setDirectUrl("127.0.0.1:8002");
+		refererConfig.setGroup("test-group");
+		refererConfig.setVersion("0.0.3");
+		refererConfig.setFilter("clientf");
+		refererConfig.setProtocol(protocolConfig);
+		refererConfig.setInterface(HelloResource.class);
+
+		resource = refererConfig.getRef();
+	}
+
+	@Test
+	public void testPrimitiveType() {
+		Assert.assertEquals("helloworld", resource.testPrimitiveType());
+	}
+
+	@Test
+	public void testCookie() {
+		List<User> users = resource.hello(23);
+		Assert.assertEquals(users.size(), 1);
+		Assert.assertEquals(users.get(0).getId(), 23);
+		Assert.assertEquals(users.get(0).getName(), "de");
+	}
+
+	@Test
+	public void testReturnResponse() {
+		Response resp = resource.add(2, "de");
+		Assert.assertEquals(resp.getStatus(), Status.OK.getStatusCode());
+		Assert.assertEquals(resp.getCookies().size(), 1);
+		Assert.assertEquals(resp.getCookies().get("ck").getName(), "ck");
+		Assert.assertEquals(resp.getCookies().get("ck").getValue(), "2");
+
+		User user = resp.readEntity(User.class);
+		resp.close();
+
+		Assert.assertEquals(user.getId(), 2);
+		Assert.assertEquals(user.getName(), "de");
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testException() {
+		resource.testException();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		serviceConfig.unexport();
+		refererConfig.destroy();
+
+		tomcat.stop();
+		tomcat.destroy();
+	}
+
+}

--- a/motan-extension/protocol-extension/motan-protocol-restful/src/test/resources/META-INF/services/com.weibo.api.motan.filter.Filter
+++ b/motan-extension/protocol-extension/motan-protocol-restful/src/test/resources/META-INF/services/com.weibo.api.motan.filter.Filter
@@ -1,0 +1,18 @@
+#
+#  Copyright 2009-2016 Weibo, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+com.weibo.api.motan.protocol.restful.ClientFilter
+com.weibo.api.motan.protocol.restful.ServerFilter

--- a/motan-extension/protocol-extension/pom.xml
+++ b/motan-extension/protocol-extension/pom.xml
@@ -7,8 +7,7 @@
     WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. ~ See the 
     License for the specific language governing permissions and ~ limitations 
     under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.weibo</groupId>
@@ -23,6 +22,7 @@
     </properties>
     <packaging>pom</packaging>
     <modules>
-        <module>motan-protocol-yar</module>
-    </modules>
+      <module>motan-protocol-yar</module>
+      <module>motan-protocol-restful</module>
+  </modules>
 </project>


### PR DESCRIPTION
添加restful协议支持

1. 支持rpc单独进程和部署到servlet容器中
2. 支持原有服务治理功能（非motan client时不支持服务发现、负载均衡等功能）
3. 支持rpc request/response的attachment机制
4. 完全支持motan rpc filter机制
5. rest服务编程完全按照JAX-RS代码方式编写