### PR TITLE
remove redundant lock

### DIFF
--- a/motan-core/src/main/java/com/weibo/api/motan/registry/support/AbstractRegistryFactory.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/registry/support/AbstractRegistryFactory.java
@@ -17,7 +17,6 @@
 package com.weibo.api.motan.registry.support;
 
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.ReentrantLock;
 
 import com.weibo.api.motan.exception.MotanErrorMsgConstant;
 import com.weibo.api.motan.exception.MotanFrameworkException;
@@ -37,8 +36,6 @@ public abstract class AbstractRegistryFactory implements RegistryFactory {
 
     private static ConcurrentHashMap<String, Registry> registries = new ConcurrentHashMap<String, Registry>();
 
-    private static final ReentrantLock lock = new ReentrantLock();
-
     protected String getRegistryUri(URL url) {
         String registryUri = url.getUri();
         return registryUri;
@@ -48,7 +45,6 @@ public abstract class AbstractRegistryFactory implements RegistryFactory {
     public Registry getRegistry(URL url) {
         String registryUri = getRegistryUri(url);
         try {
-            lock.lock();
             Registry registry = registries.get(registryUri);
             if (registry != null) {
                 return registry;
@@ -57,12 +53,10 @@ public abstract class AbstractRegistryFactory implements RegistryFactory {
             if (registry == null) {
                 throw new MotanFrameworkException("Create registry false for url:" + url, MotanErrorMsgConstant.FRAMEWORK_INIT_ERROR);
             }
-            registries.put(registryUri, registry);
+            registries.putIfAbsent(registryUri, registry);
             return registry;
         } catch (Exception e) {
             throw new MotanFrameworkException("Create registry false for url:" + url, e, MotanErrorMsgConstant.FRAMEWORK_INIT_ERROR);
-        } finally {
-            lock.unlock();
         }
     }
 


### PR DESCRIPTION
ConcurrentHashMap可以保证线程安全， 这里的lock是多余的， 并且会影响并发的性能。