### PR TITLE
add maven-javadoc-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.9.1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>


### PR DESCRIPTION
maven 3.5.2 运行 `mvn clean install` 出现错误：

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.0:jar (attach-javadocs) on project motan-core: MavenReportException: Error while generating Javadoc:

应该是 maven 和 maven-javadoc-plugin 的一个 bug

指定 maven-javadoc-plugin 版本能够避免该错误的出现

Signed-off-by: Zhao Junwang <zhjwpku@gmail.com>