### PR TITLE
Update AnnotationBean.java

### DIFF
--- a/motan-springsupport/src/main/java/com/weibo/api/motan/config/springsupport/AnnotationBean.java
+++ b/motan-springsupport/src/main/java/com/weibo/api/motan/config/springsupport/AnnotationBean.java
@@ -137,7 +137,7 @@ public class AnnotationBean implements DisposableBean, BeanFactoryPostProcessor,
                             method.invoke(bean, new Object[]{value});
                         }
                     }
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     throw new BeanInitializationException("Failed to init remote service reference at method " + name
                             + " in class " + bean.getClass().getName(), e);
                 }


### PR DESCRIPTION
MotanReferer标注的接口可能抛出Error而不是Exception，这里改为捕获Throwable以便跟踪具体异常。
近期发现有个NoClassDefFoundError问题，一个rpc接口引入了一个新方法，方法返回值是net.sf.json.JSONArray，而项目中并未引入这个JSONArray，从而触发了NoClassDefFoundError，而异常栈并不能看出来具体是哪个rpc接口触发了这个异常，所以在初始化Referer时捕获Throwable，以期能输出有效的异常信息