### PR TITLE
Fix the dependency conflict issue

### DIFF
--- a/motan-benchmark/pom.xml
+++ b/motan-benchmark/pom.xml
@@ -50,12 +50,12 @@
         </dependency>
         <dependency>
             <groupId>com.weibo</groupId>
-            <artifactId>motan-transport-netty</artifactId>
+            <artifactId>motan-registry-zookeeper</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>com.weibo</groupId>
-            <artifactId>motan-registry-zookeeper</artifactId>
+            <artifactId>motan-transport-netty</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fix the dependency conflict issue #809 by reversing the declaration order of **_com.weibo:motan-transport-netty:jar:0.2.1:compile_**  and **_com.weibo:motan-registry-zookeeper:jar:0.2.1:compile_** in pom file, which transitively introduce the conclicting libraries.
This fix will not affect other libraries or class, except the above duplicate class.