### PR TITLE
Fix issue#861

### DIFF
--- a/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/NettyDecoder.java
+++ b/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/NettyDecoder.java
@@ -38,7 +38,7 @@ public class NettyDecoder extends ByteToMessageDecoder {
         in.markReaderIndex();
         short type = in.readShort();
         if (type != MotanConstants.NETTY_MAGIC_TYPE) {
-            in.resetReaderIndex();
+            in.skipBytes(in.readableBytes());
             throw new MotanFrameworkException("NettyDecoder transport header not support, type: " + type);
         }
         in.skipBytes(1);

--- a/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/NettyDecoder.java
+++ b/motan-transport-netty4/src/main/java/com/weibo/api/motan/transport/netty4/NettyDecoder.java
@@ -69,6 +69,7 @@ public class NettyDecoder extends ByteToMessageDecoder {
         int metaSize = in.readInt();
         size += 4;
         if (metaSize > 0) {
+            checkMaxContext(metaSize, ctx, in, isRequest, requestId, RpcProtocolVersion.VERSION_2);
             size += metaSize;
             if (in.readableBytes() < metaSize) {
                 in.resetReaderIndex();
@@ -81,9 +82,9 @@ public class NettyDecoder extends ByteToMessageDecoder {
             return;
         }
         int bodySize = in.readInt();
-        checkMaxContext(bodySize, ctx, isRequest, requestId, RpcProtocolVersion.VERSION_2);
         size += 4;
         if (bodySize > 0) {
+            checkMaxContext(bodySize, ctx, in, isRequest, requestId, RpcProtocolVersion.VERSION_2);
             size += bodySize;
             if (in.readableBytes() < bodySize) {
                 in.resetReaderIndex();
@@ -108,21 +109,23 @@ public class NettyDecoder extends ByteToMessageDecoder {
         long requestId = in.readLong();
         int dataLength = in.readInt();
 
-        // FIXME 如果dataLength过大，可能导致问题
+        checkMaxContext(dataLength, ctx, in, messageType == MotanConstants.FLAG_REQUEST, requestId, RpcProtocolVersion.VERSION_1);
         if (in.readableBytes() < dataLength) {
             in.resetReaderIndex();
             return;
         }
-        checkMaxContext(dataLength, ctx, messageType == MotanConstants.FLAG_REQUEST, requestId, RpcProtocolVersion.VERSION_1);
         byte[] data = new byte[dataLength];
         in.readBytes(data);
         decode(data, out, messageType == MotanConstants.FLAG_REQUEST, requestId, RpcProtocolVersion.VERSION_1).setStartTime(startTime);
     }
 
-    private void checkMaxContext(int dataLength, ChannelHandlerContext ctx, boolean isRequest, long requestId, RpcProtocolVersion version) throws Exception {
+    private void checkMaxContext(int dataLength, ChannelHandlerContext ctx, ByteBuf byteBuf, boolean isRequest, long requestId, RpcProtocolVersion version) throws Exception {
         if (maxContentLength > 0 && dataLength > maxContentLength) {
             LoggerUtil.warn("NettyDecoder transport data content length over of limit, size: {}  > {}. remote={} local={}",
                     dataLength, maxContentLength, ctx.channel().remoteAddress(), ctx.channel().localAddress());
+            // skip all readable Bytes in order to release this no-readable bytebuf in super.channelRead()
+            // that avoid this.decode() being invoked again after channel.close()
+            byteBuf.skipBytes(byteBuf.readableBytes());
             Exception e = new MotanServiceException("NettyDecoder transport data content length over of limit, size: " + dataLength + " > " + maxContentLength);
             if (isRequest) {
                 Response response = MotanFrameworkUtil.buildErrorResponse(requestId, version.getVersion(), e);

--- a/motan-transport-netty4/src/test/java/com/weibo/api/motan/transport/netty4/NettyDecoderTest.java
+++ b/motan-transport-netty4/src/test/java/com/weibo/api/motan/transport/netty4/NettyDecoderTest.java
@@ -1,0 +1,136 @@
+package com.weibo.api.motan.transport.netty4;
+
+import com.weibo.api.motan.codec.Codec;
+import com.weibo.api.motan.common.MotanConstants;
+import com.weibo.api.motan.exception.MotanFrameworkException;
+import com.weibo.api.motan.exception.MotanServiceException;
+import com.weibo.api.motan.protocol.v2motan.MotanV2Codec;
+import com.weibo.api.motan.rpc.*;
+import com.weibo.api.motan.transport.Channel;
+import com.weibo.api.motan.transport.MessageHandler;
+import com.weibo.api.motan.util.RequestIdGenerator;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author single-wolf root@mail.zhongm.in
+ */
+public class NettyDecoderTest {
+
+    private NettyServer nettyServer;
+    private MessageHandler messageHandler;
+    private URL url;
+    private String interfaceName = "com.weibo.api.motan.protocol.example.IHello";
+
+    @Before
+    public void setUp() {
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put("requestTimeout", "500");
+
+        url = new URL("netty", "localhost", 18080, interfaceName, parameters);
+        messageHandler = new MessageHandler() {
+            @Override
+            public Object handle(Channel channel, Object message) {
+                Request request = (Request) message;
+                DefaultResponse response = new DefaultResponse();
+                response.setRequestId(request.getRequestId());
+                response.setValue("method: " + request.getMethodName() + " requestId: " + request.getRequestId());
+
+                return response;
+            }
+        };
+        nettyServer = new NettyServer(url, messageHandler);
+        nettyServer.open();
+    }
+
+    @After
+    public void tearDown() {
+        nettyServer.close();
+    }
+
+    @Test
+    public void repeatDecodeInvokedByOldCode() {
+        NettyOldFakeDecoder nettyDecoder = new NettyOldFakeDecoder(new MotanV2Codec(), nettyServer, 24);
+        NettyChannelHandler handler = new NettyChannelHandler(nettyServer, messageHandler, (ThreadPoolExecutor) Executors.newFixedThreadPool(4));
+
+        EmbeddedChannel channel = new EmbeddedChannel(nettyDecoder, handler);
+
+        ByteBuf buf = Unpooled.wrappedBuffer(new byte[]{'a', 'b', 'c', 'd', 'e', 'a', 'b', 'c', 'd', 'e', 'a', 'b', 'c', 'd',
+                'e', 'a', 'b', 'c', 'd', 'e',});
+        channel.writeInbound(buf.copy());
+        buf.release();
+        assertEquals(false, 1 == nettyDecoder.getDecodeInvokeCnt());
+    }
+
+
+    @Test
+    public void onlyOneDecodeInvoked() {
+        NettyNewCntDecoder nettyDecoder = new NettyNewCntDecoder(new MotanV2Codec(), nettyServer, 24);
+        NettyChannelHandler handler = new NettyChannelHandler(nettyServer, messageHandler, (ThreadPoolExecutor) Executors.newFixedThreadPool(4));
+
+        EmbeddedChannel channel = new EmbeddedChannel(nettyDecoder, handler);
+
+        ByteBuf buf = Unpooled.wrappedBuffer(new byte[]{'a', 'b', 'c', 'd', 'e', 'a', 'b', 'c', 'd', 'e', 'a', 'b', 'c', 'd',
+                'e', 'a', 'b', 'c', 'd', 'e',});
+        channel.writeInbound(buf.copy());
+        buf.release();
+        assertEquals(true, 1 == nettyDecoder.getDecodeInvokeCnt());
+    }
+
+    class NettyOldFakeDecoder extends NettyDecoder {
+
+        private int decodeInvokeCnt = 0;
+
+        public NettyOldFakeDecoder(Codec codec, Channel channel, int maxContentLength) {
+            super(codec, channel, maxContentLength);
+        }
+
+        @Override
+        protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+            decodeInvokeCnt++;
+            in.markReaderIndex();
+            short type = in.readShort();
+            if (type != MotanConstants.NETTY_MAGIC_TYPE) {
+                in.resetReaderIndex();
+                throw new MotanFrameworkException("NettyDecoder transport header not support, type: " + type);
+            }
+            throw new MotanServiceException("NettyDecoder transport data content length over of limit");
+        }
+
+        public int getDecodeInvokeCnt() {
+            return decodeInvokeCnt;
+        }
+    }
+
+    class NettyNewCntDecoder extends NettyDecoder {
+
+        private int decodeInvokeCnt = 0;
+
+        public NettyNewCntDecoder(Codec codec, Channel channel, int maxContentLength) {
+            super(codec, channel, maxContentLength);
+        }
+
+        @Override
+        protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+            decodeInvokeCnt++;
+            super.decode(ctx, in, out);
+        }
+
+        public int getDecodeInvokeCnt() {
+            return decodeInvokeCnt;
+        }
+    }
+}


### PR DESCRIPTION
Motivation:
1. Not check the length to be read from the peer that will consume a lot of memory by a poisonous message
2. Not release byteBuf before close channel when meeting length check exception

Modifications:
1. Add length check in NettyDecoder
2. release byteBuf before throw exception in NettyDecoder