### PR TITLE
ServiceConfigBean移除对BeanPostProcessor接口的实现

### DIFF
--- a/motan-springsupport/src/main/java/com/weibo/api/motan/config/springsupport/ServiceConfigBean.java
+++ b/motan-springsupport/src/main/java/com/weibo/api/motan/config/springsupport/ServiceConfigBean.java
@@ -29,7 +29,6 @@ import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
 
@@ -46,7 +45,6 @@ import com.weibo.api.motan.util.MotanFrameworkUtil;
 
 public class ServiceConfigBean<T> extends ServiceConfig<T>
         implements
-        BeanPostProcessor,
         BeanFactoryAware,
         InitializingBean,
         DisposableBean,
@@ -76,17 +74,6 @@ public class ServiceConfigBean<T> extends ServiceConfig<T>
     @Override
     public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
         this.beanFactory = beanFactory;
-    }
-
-    // 为了让serviceBean最早加载
-    @Override
-    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
-        return bean;
-    }
-
-    @Override
-    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-        return bean;
     }
 
     @Override
@@ -190,5 +177,4 @@ public class ServiceConfigBean<T> extends ServiceConfig<T>
             setRegistry(MotanFrameworkUtil.getDefaultRegistryConfig());
         }
     }
-
 }


### PR DESCRIPTION
我们试图优化项目启动速度，使用并行的方式加载项目bean。由于motan ServiceConfigBean实现了BeanPostProcessor接口，导致spring框架会优先其他bean加载motanService bean及其依赖。这种方式导致了motan项目在启动时无法享受到bean的并行加载。
考虑删除ServiceConfigBean的BeanPostProcessor实现，使其及其依赖bean放在可以在一般bean初始化流程中加载，而非优先加载。
此种方式也可以使其他自定义的BeanPostProcessor在ServiceConfigBean及其依赖bean的初始化时生效。