### PR TITLE
Use 'volatile' to mark flag variable thread safety.

### DIFF
--- a/motan-core/src/main/java/com/weibo/api/motan/rpc/init/InitializationFactory.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/rpc/init/InitializationFactory.java
@@ -29,7 +29,7 @@ import com.weibo.api.motan.util.LoggerUtil;
  *
  */
 public class InitializationFactory {
-    private static boolean inited = false;
+    private static volatile boolean inited = false;
     private static Initializable instance = new AllSpiInitialization();
 
     public static Initializable getInitialization() {


### PR DESCRIPTION
Use 'volatile' to mark flag variable thread safety.