### PR TITLE
RefererConfigBean getObjectType not return null value

### DIFF
--- a/motan-springsupport/src/main/java/com/weibo/api/motan/config/springsupport/RefererConfigBean.java
+++ b/motan-springsupport/src/main/java/com/weibo/api/motan/config/springsupport/RefererConfigBean.java
@@ -42,7 +42,11 @@ public class RefererConfigBean<T> extends RefererConfig<T> implements FactoryBea
 
     @Override
     public Class<?> getObjectType() {
-        return getInterface();
+        Class clz = getInterface();
+        if (clz == null){ // if interfaceClass is not set
+            clz = this.getClass(); // avoid being initialized prematurely before placeholder is processed
+        }
+        return clz;
     }
 
     @Override


### PR DESCRIPTION
RefererConfigBean getObjectType return default class when interface class is not set