### PR TITLE
RefererConfigBean getObjectType not return null value

### DIFF
--- a/motan-core/src/main/java/com/weibo/api/motan/core/extension/ActivationComparator.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/core/extension/ActivationComparator.java
@@ -29,7 +29,7 @@ import java.util.Comparator;
 public class ActivationComparator<T> implements Comparator<T> {
 
     /**
-     * sequence 大的排在后面,如果没有设置sequence的排到最前面
+     * sequence 大的排在后面,如果没有设置sequence的排到最后面
      */
     @Override
     public int compare(T o1, T o2) {

--- a/motan-springsupport/src/main/java/com/weibo/api/motan/config/springsupport/RefererConfigBean.java
+++ b/motan-springsupport/src/main/java/com/weibo/api/motan/config/springsupport/RefererConfigBean.java
@@ -42,7 +42,11 @@ public class RefererConfigBean<T> extends RefererConfig<T> implements FactoryBea
 
     @Override
     public Class<?> getObjectType() {
-        return getInterface();
+        Class<?> clz = getInterface();
+        if (clz == null){ // if interfaceClass is not set
+            clz = this.getClass(); // avoid being initialized prematurely before placeholder is processed
+        }
+        return clz;
     }
 
     @Override


### PR DESCRIPTION
RefererConfigBean getObjectType return default class when interface class is not set
