### PR TITLE
fix(sec): upgrade org.springframework:spring-web to 5.2.15.RELEASE

### DIFF
--- a/motan-benchmark/pom.xml
+++ b/motan-benchmark/pom.xml
@@ -13,11 +13,7 @@
   ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>motan</artifactId>
         <groupId>com.weibo</groupId>
@@ -66,7 +62,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>4.2.4.RELEASE</version>
+            <version>5.2.15.RELEASE</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in org.springframework:spring-web 5.2.7.RELEASE
- [CVE-2020-5421](https://www.oscs1024.com/hd/CVE-2020-5421)
- [CVE-2021-22118](https://www.oscs1024.com/hd/CVE-2021-22118)


### What did I do？
Upgrade org.springframework:spring-web from 5.2.7.RELEASE to 5.2.15.RELEASE for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS