### PR TITLE
fix(sec): upgrade io.netty:netty-all to 4.1.44.Final

### DIFF
--- a/motan-demo/pom.xml
+++ b/motan-demo/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~  Copyright 2009-2016 Weibo, Inc.
   ~
@@ -13,11 +13,7 @@
   ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
-  -->
-
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.weibo</groupId>
@@ -119,7 +115,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.3.Final</version> <!-- to be compatible with motan-protocol-grpc modules -->
+            <version>4.1.44.Final</version> <!-- to be compatible with motan-protocol-grpc modules -->
         </dependency>
 
         <!-- log4j -->

--- a/motan-transport-netty4/pom.xml
+++ b/motan-transport-netty4/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>motan</artifactId>
         <groupId>com.weibo</groupId>
@@ -20,7 +18,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.42.Final</version>
+            <version>4.1.44.Final</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### What happened？
There are 4 security vulnerabilities found in io.netty:netty-all 4.1.3.Final
- [CVE-2019-16869](https://www.oscs1024.com/hd/CVE-2019-16869)
- [CVE-2020-7238](https://www.oscs1024.com/hd/CVE-2020-7238)
- [CVE-2019-20444](https://www.oscs1024.com/hd/CVE-2019-20444)
- [CVE-2019-20445](https://www.oscs1024.com/hd/CVE-2019-20445)


### What did I do？
Upgrade io.netty:netty-all from 4.1.3.Final to 4.1.44.Final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS