### PR TITLE
fix(sec): upgrade org.jboss.resteasy:resteasy-client to 4.5.8.SP1

### DIFF
--- a/motan-extension/protocol-extension/motan-protocol-restful/pom.xml
+++ b/motan-extension/protocol-extension/motan-protocol-restful/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~  Copyright 2009-2016 Weibo, Inc.
   ~
@@ -13,11 +13,7 @@
   ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~    See the License for the specific language governing permissions and
   ~    limitations under the License.
-  -->
-
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-         xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.weibo</groupId>
@@ -27,7 +23,7 @@
     <artifactId>motan-protocol-restful</artifactId>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <resteasy.version>3.14.0.Final</resteasy.version>
+        <resteasy.version>4.5.8.SP1</resteasy.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.jboss.resteasy:resteasy-client 3.14.0.Final
- [CVE-2020-25633](https://www.oscs1024.com/hd/CVE-2020-25633)


### What did I do？
Upgrade org.jboss.resteasy:resteasy-client from 3.14.0.Final to 4.5.8.SP1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS