### PR TITLE
CommonClient generalized calls support motan1 protocol

### DIFF
--- a/motan-core/src/main/java/com/weibo/api/motan/proxy/CommonClient.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/proxy/CommonClient.java
@@ -59,4 +59,11 @@ public interface CommonClient {
      * build request with interfaceName, methodName and arguments
      */
     Request buildRequest(String interfaceName, String methodName, Object[] arguments);
+
+    Object callV1(String methodName, Object[] arguments, String parametersDesc,Class<?> returnType) throws Throwable;
+
+    /**
+     * call a service method asynchronously
+     */
+    Object asyncCallV1(String methodName, Object[] arguments, String parametersDesc,Class<?> returnType) throws Throwable;
 }

--- a/motan-core/src/main/java/com/weibo/api/motan/proxy/MeshClientRefererInvocationHandler.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/proxy/MeshClientRefererInvocationHandler.java
@@ -133,4 +133,14 @@ public class MeshClientRefererInvocationHandler<T> extends AbstractRefererHandle
     public Request buildRequest(String interfaceName, String methodName, Object[] arguments) {
         return MotanClientUtil.buildRequest(interfaceName, methodName, arguments);
     }
+
+    @Override
+    public Object callV1(String methodName, Object[] arguments, String parametersDesc, Class<?> returnType) throws Throwable {
+        return null;
+    }
+
+    @Override
+    public Object asyncCallV1(String methodName, Object[] arguments, String parametersDesc, Class<?> returnType) throws Throwable {
+        return null;
+    }
 }

--- a/motan-core/src/main/java/com/weibo/api/motan/proxy/RefererCommonHandler.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/proxy/RefererCommonHandler.java
@@ -46,4 +46,18 @@ public class RefererCommonHandler<T> extends AbstractRefererHandler<T> implement
     public Request buildRequest(String interfaceName, String methodName, Object[] arguments) {
         return MotanClientUtil.buildRequest(interfaceName, methodName, arguments);
     }
+
+    public Request buildRequestV1(String interfaceName, String methodName, Object[] arguments,String parametersDesc) {
+        return MotanClientUtil.buildRequestV1(interfaceName, methodName, arguments,parametersDesc);
+    }
+
+    @Override
+    public Object callV1(String methodName, Object[] arguments, String parametersDesc, Class<?> returnType) throws Throwable {
+        return invokeRequest(buildRequestV1(interfaceName,methodName, arguments,parametersDesc), returnType, false);
+    }
+
+    @Override
+    public Object asyncCallV1(String methodName, Object[] arguments, String parametersDesc, Class<?> returnType) throws Throwable {
+        return invokeRequest(buildRequestV1(interfaceName,methodName, arguments,parametersDesc), returnType, true);
+    }
 }

--- a/motan-core/src/main/java/com/weibo/api/motan/util/MotanClientUtil.java
+++ b/motan-core/src/main/java/com/weibo/api/motan/util/MotanClientUtil.java
@@ -35,6 +35,10 @@ public class MotanClientUtil {
         return buildRequest(interfaceName, methodName, arguments, null);
     }
 
+    public static Request buildRequestV1(String interfaceName, String methodName, Object[] arguments,String parametersDesc) {
+        return buildRequest(interfaceName, methodName, parametersDesc,arguments, null);
+    }
+
     public static Request buildRequest(String interfaceName, String methodName, Object[] arguments, Map<String, String> attachments) {
         return buildRequest(interfaceName, methodName, null, arguments, attachments);
     }

--- a/motan-demo/motan-demo-api/src/main/java/com/weibo/motan/demo/service/MotanDemoService.java
+++ b/motan-demo/motan-demo-api/src/main/java/com/weibo/motan/demo/service/MotanDemoService.java
@@ -25,4 +25,6 @@ public interface MotanDemoService {
 
     User rename(User user, String name) throws Exception;
 
+
+    String getInfo(int i);
 }

--- a/motan-demo/motan-demo-api/src/main/java/com/weibo/motan/demo/service/MotanDemoService.java
+++ b/motan-demo/motan-demo-api/src/main/java/com/weibo/motan/demo/service/MotanDemoService.java
@@ -26,5 +26,5 @@ public interface MotanDemoService {
     User rename(User user, String name) throws Exception;
 
 
-    String getInfo(int i);
+    String getUsername(int id);
 }

--- a/motan-demo/motan-demo-client/src/main/java/com/weibo/motan/demo/client/Motan1RpcClient.java
+++ b/motan-demo/motan-demo-client/src/main/java/com/weibo/motan/demo/client/Motan1RpcClient.java
@@ -1,0 +1,76 @@
+/*
+ *
+ *   Copyright 2009-2016 Weibo, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package com.weibo.motan.demo.client;
+
+import com.weibo.api.motan.config.ProtocolConfig;
+import com.weibo.api.motan.config.RefererConfig;
+import com.weibo.api.motan.config.RegistryConfig;
+import com.weibo.api.motan.proxy.CommonClient;
+import com.weibo.api.motan.rpc.Request;
+import com.weibo.api.motan.rpc.ResponseFuture;
+import com.weibo.motan.demo.service.MotanDemoService;
+import com.weibo.motan.demo.service.PbParamService;
+import com.weibo.motan.demo.service.model.User;
+import io.grpc.examples.routeguide.Point;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+public class Motan1RpcClient {
+
+    public static void main(String[] args) throws Throwable {
+        //motan（V1）协议使用CommonClient实现泛化调用
+        RefererConfig<CommonClient> motanDemoServiceReferer = new RefererConfig<CommonClient>();
+
+        // 设置接口及实现类
+        motanDemoServiceReferer.setInterface(CommonClient.class);
+        motanDemoServiceReferer.setServiceInterface("com.weibo.motan.demo.service.MotanDemoService");
+
+
+        // 配置服务的group以及版本号
+        motanDemoServiceReferer.setGroup("motan-demo-rpc");
+        motanDemoServiceReferer.setVersion("1.0");
+        motanDemoServiceReferer.setRequestTimeout(1000);
+        motanDemoServiceReferer.setAsyncInitConnection(false);
+
+        // 配置注册中心直连调用
+        RegistryConfig registry = new RegistryConfig();
+
+        //use direct registry
+        registry.setRegProtocol("direct");
+        registry.setAddress("127.0.0.1:8001");
+
+        // use ZooKeeper registry
+//        registry.setRegProtocol("zk");
+//        registry.setAddress("127.0.0.1:2181");
+        motanDemoServiceReferer.setRegistry(registry);
+
+        // 配置RPC协议
+        ProtocolConfig protocol = new ProtocolConfig();
+        protocol.setId("motan");
+        protocol.setName("motan");
+        motanDemoServiceReferer.setProtocol(protocol);
+        // motanDemoServiceReferer.setDirectUrl("localhost:8002");  // 注册中心直连调用需添加此配置
+
+        // 使用服务
+        CommonClient service = motanDemoServiceReferer.getRef();
+
+        System.out.println(service.callV1("hello", new Object[]{"a"},"java.lang.String", String.class));
+    }
+
+}

--- a/motan-demo/motan-demo-client/src/main/java/com/weibo/motan/demo/client/Motan2RpcClient.java
+++ b/motan-demo/motan-demo-client/src/main/java/com/weibo/motan/demo/client/Motan2RpcClient.java
@@ -151,7 +151,7 @@ public class Motan2RpcClient {
 
         // 使用服务
         CommonClient client = referer.getRef();
-        System.out.println(client.call("getInfo", new Object[]{999}, String.class));
+        System.out.println(client.call("getUsername", new Object[]{999}, String.class));
     }
 
 }

--- a/motan-demo/motan-demo-client/src/main/java/com/weibo/motan/demo/client/Motan2RpcClient.java
+++ b/motan-demo/motan-demo-client/src/main/java/com/weibo/motan/demo/client/Motan2RpcClient.java
@@ -56,6 +56,7 @@ public class Motan2RpcClient {
         CommonClient xmlClient = (CommonClient) ctx.getBean("motanDemoReferer-common-client");
         motan2XmlCommonClientDemo(xmlClient);
         motan2ApiCommonClientDemo();
+        motan2ApiCommonClientDemo2();
 
         System.out.println("motan demo is finish.");
         System.exit(0);
@@ -121,6 +122,36 @@ public class Motan2RpcClient {
         // 使用服务
         CommonClient client = referer.getRef();
         System.out.println(client.call("hello", new Object[]{"a"}, String.class));
+    }
+
+    public static void motan2ApiCommonClientDemo2() throws Throwable {
+        RefererConfig<CommonClient> referer = new RefererConfig<>();
+
+        // 设置服务端接口
+        referer.setInterface(CommonClient.class);
+        referer.setServiceInterface("com.weibo.motan.demo.service.MotanDemoService");
+
+        // 配置服务的group以及版本号
+        referer.setGroup("motan-demo-rpc");
+        referer.setVersion("1.0");
+        referer.setRequestTimeout(1000);
+        referer.setAsyncInitConnection(false);
+
+        // 配置注册中心直连调用
+        RegistryConfig registry = new RegistryConfig();
+        registry.setRegProtocol("direct");
+        registry.setAddress("127.0.0.1:8001");
+        referer.setRegistry(registry);
+
+        // 配置RPC协议
+        ProtocolConfig protocol = new ProtocolConfig();
+        protocol.setId("motan2");
+        protocol.setName("motan2");
+        referer.setProtocol(protocol);
+
+        // 使用服务
+        CommonClient client = referer.getRef();
+        System.out.println(client.call("getInfo", new Object[]{999}, String.class));
     }
 
 }

--- a/motan-demo/motan-demo-server/src/main/java/com/weibo/motan/demo/server/MotanDemoServiceImpl.java
+++ b/motan-demo/motan-demo-server/src/main/java/com/weibo/motan/demo/server/MotanDemoServiceImpl.java
@@ -40,8 +40,8 @@ public class MotanDemoServiceImpl implements MotanDemoService {
     }
 
     @Override
-    public String getInfo(int i) {
-        return "call success:"+ i;
+    public String getUsername(int id) {
+        return "your id is:"+ id;
     }
 
 }

--- a/motan-demo/motan-demo-server/src/main/java/com/weibo/motan/demo/server/MotanDemoServiceImpl.java
+++ b/motan-demo/motan-demo-server/src/main/java/com/weibo/motan/demo/server/MotanDemoServiceImpl.java
@@ -39,4 +39,9 @@ public class MotanDemoServiceImpl implements MotanDemoService {
         return user;
     }
 
+    @Override
+    public String getInfo(int i) {
+        return "call success:"+ i;
+    }
+
 }


### PR DESCRIPTION
many companies are still using the old protocol(motan V1)，but generalized calls are not supported.
The motan2 protocol supported generalized calls through the CommonClient，but not support motan1 protocol.
I've supported it since I passed the makeover
